### PR TITLE
plancast attendees integration

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,17 +4,43 @@
   <link rel="alternate" type="application/x-wiki" title="Edit this page" href="<%= edit_event_url(@event) %>" />
 <% end %>
 
+<% content_for :javascript_insert do %>
+  <script src="/javascripts/mustache.js" type="text/javascript"></script> 
+  <script type='text/javascript'>
+    $(function() {
+      var plan = $('.external.plancast.plan:first');
+      if (plan.length > 0) {
+        var plan_id = parseInt(plan.text().split('=')[1]).toString(36);
+        $.ajax({
+          url: "http://jsonpify.heroku.com",
+          dataType: 'jsonp',
+          data: {
+            resource: "http://api.plancast.com/02/plans/show.json",
+            extensions: "attendees",
+            plan_id: plan_id
+          },
+          success: function(data) {
+            if (data.attendees.length > 0) {
+              $('.attendees').append(Mustache.to_html($('#attendees-template').html(), data));
+            }
+          }
+        });
+      }
+    })
+  </script>
+<% end %>
+
 <div class="single_event contentbar">
   <div class="vevent">
     <h1 class="summary"><%= cleanse @event.title.strip_html %></h1>
     <div class='date'><%= normalize_time(@event) -%></div>
       <% unless @event.venue.blank? %>
       <div class="location vcard">
-      <%= google_map @event %>
-          <a class="url" href='<%= url_for venue_url(@event.venue) %>'>
-            <span class='fn org'><%= cleanse @event.venue.title.strip_html -%></span>
-          </a>
-          <div class="adr">
+        <%= google_map @event %>
+        <a class="url" href='<%= url_for venue_url(@event.venue) %>'>
+          <span class='fn org'><%= cleanse @event.venue.title.strip_html -%></span>
+        </a>
+        <div class="adr">
           <% if !@event.venue.street_address.blank? -%>
           <div class="street-address"><%= cleanse @event.venue.street_address -%></div>
           <% end %>
@@ -33,15 +59,31 @@
             <% if @event.venue && @event.venue.has_full_address? -%>
             (<a href='<%=google_maps_url(@event.venue.full_address) -%>'>map</a>)
             <% end -%>
-      </div>
-    </div>
-    <% end -%>
-      <% unless @event.url.blank? -%>
-        <h3>Website</h3>
-        <div class="website">
-          <%= link_to "#{truncate(@event.url, :length => 128)}", h(@event.url), :class => "url", :rel => "nofollow" -%>
         </div>
-      <% end -%>
+      </div>
+    <% end -%>
+    <div class="attendees">
+      <script id="attendees-template" type="text/mustache">
+        <h3>Attendees</h3>
+        <span class='plancast-rsvp'>(<a href="{{plan_url}}">RSVP on Plancast</a>)</span>
+        <br />
+        <ul>
+          {{#attendees}}
+            <li>
+              <a href='http://plancast.com/{{username}}'>
+                <img class='avatar' src='{{pic_square}}'/>
+              </a>
+            </li> 
+          {{/attendees}}
+        </ul>
+      </script>
+    </div>
+    <% unless @event.url.blank? -%>
+      <h3>Website</h3>
+      <div class="website">
+        <%= link_to "#{truncate(@event.url, :length => 128)}", h(@event.url), :class => "url", :rel => "nofollow" -%>
+      </div>
+    <% end -%>
     <% unless @event.description.blank? -%>
     <h3>Description</h3>
     <div class="description">
@@ -56,7 +98,7 @@
     <% end %>
   </div>
 </div>
-        
+
 <div class='single_view_right sidebar'>
   <h3 class='first'>Export to</h3>
   <ul>

--- a/public/javascripts/mustache.js
+++ b/public/javascripts/mustache.js
@@ -1,0 +1,325 @@
+/*
+  mustache.js — Logic-less templates in JavaScript
+
+  See http://mustache.github.com/ for more info.
+*/
+
+var Mustache = function() {
+  var Renderer = function() {};
+
+  Renderer.prototype = {
+    otag: "{{",
+    ctag: "}}",
+    pragmas: {},
+    buffer: [],
+    pragmas_implemented: {
+      "IMPLICIT-ITERATOR": true
+    },
+    context: {},
+
+    render: function(template, context, partials, in_recursion) {
+      // reset buffer & set context
+      if(!in_recursion) {
+        this.context = context;
+        this.buffer = []; // TODO: make this non-lazy
+      }
+
+      // fail fast
+      if(!this.includes("", template)) {
+        if(in_recursion) {
+          return template;
+        } else {
+          this.send(template);
+          return;
+        }
+      }
+
+      template = this.render_pragmas(template);
+      var html = this.render_section(template, context, partials);
+      if(in_recursion) {
+        return this.render_tags(html, context, partials, in_recursion);
+      }
+
+      this.render_tags(html, context, partials, in_recursion);
+    },
+
+    /*
+      Sends parsed lines
+    */
+    send: function(line) {
+      if(line != "") {
+        this.buffer.push(line);
+      }
+    },
+
+    /*
+      Looks for %PRAGMAS
+    */
+    render_pragmas: function(template) {
+      // no pragmas
+      if(!this.includes("%", template)) {
+        return template;
+      }
+
+      var that = this;
+      var regex = new RegExp(this.otag + "%([\\w-]+) ?([\\w]+=[\\w]+)?" +
+            this.ctag);
+      return template.replace(regex, function(match, pragma, options) {
+        if(!that.pragmas_implemented[pragma]) {
+          throw({message: 
+            "This implementation of mustache doesn't understand the '" +
+            pragma + "' pragma"});
+        }
+        that.pragmas[pragma] = {};
+        if(options) {
+          var opts = options.split("=");
+          that.pragmas[pragma][opts[0]] = opts[1];
+        }
+        return "";
+        // ignore unknown pragmas silently
+      });
+    },
+
+    /*
+      Tries to find a partial in the curent scope and render it
+    */
+    render_partial: function(name, context, partials) {
+      name = this.trim(name);
+      if(!partials || partials[name] === undefined) {
+        throw({message: "unknown_partial '" + name + "'"});
+      }
+      if(typeof(context[name]) != "object") {
+        return this.render(partials[name], context, partials, true);
+      }
+      return this.render(partials[name], context[name], partials, true);
+    },
+
+    /*
+      Renders inverted (^) and normal (#) sections
+    */
+    render_section: function(template, context, partials) {
+      if(!this.includes("#", template) && !this.includes("^", template)) {
+        return template;
+      }
+
+      var that = this;
+      // CSW - Added "+?" so it finds the tighest bound, not the widest
+      var regex = new RegExp(this.otag + "(\\^|\\#)\\s*(.+)\\s*" + this.ctag +
+              "\n*([\\s\\S]+?)" + this.otag + "\\/\\s*\\2\\s*" + this.ctag +
+              "\\s*", "mg");
+
+      // for each {{#foo}}{{/foo}} section do...
+      return template.replace(regex, function(match, type, name, content) {
+        var value = that.find(name, context);
+        if(type == "^") { // inverted section
+          if(!value || that.is_array(value) && value.length === 0) {
+            // false or empty list, render it
+            return that.render(content, context, partials, true);
+          } else {
+            return "";
+          }
+        } else if(type == "#") { // normal section
+          if(that.is_array(value)) { // Enumerable, Let's loop!
+            return that.map(value, function(row) {
+              return that.render(content, that.create_context(row),
+                partials, true);
+            }).join("");
+          } else if(that.is_object(value)) { // Object, Use it as subcontext!
+            return that.render(content, that.create_context(value),
+              partials, true);
+          } else if(typeof value === "function") {
+            // higher order section
+            return value.call(context, content, function(text) {
+              return that.render(text, context, partials, true);
+            });
+          } else if(value) { // boolean section
+            return that.render(content, context, partials, true);
+          } else {
+            return "";
+          }
+        }
+      });
+    },
+
+    /*
+      Replace {{foo}} and friends with values from our view
+    */
+    render_tags: function(template, context, partials, in_recursion) {
+      // tit for tat
+      var that = this;
+
+      var new_regex = function() {
+        return new RegExp(that.otag + "(=|!|>|\\{|%)?([^\\/#\\^]+?)\\1?" +
+          that.ctag + "+", "g");
+      };
+
+      var regex = new_regex();
+      var tag_replace_callback = function(match, operator, name) {
+        switch(operator) {
+        case "!": // ignore comments
+          return "";
+        case "=": // set new delimiters, rebuild the replace regexp
+          that.set_delimiters(name);
+          regex = new_regex();
+          return "";
+        case ">": // render partial
+          return that.render_partial(name, context, partials);
+        case "{": // the triple mustache is unescaped
+          return that.find(name, context);
+        default: // escape the value
+          return that.escape(that.find(name, context));
+        }
+      };
+      var lines = template.split("\n");
+      for(var i = 0; i < lines.length; i++) {
+        lines[i] = lines[i].replace(regex, tag_replace_callback, this);
+        if(!in_recursion) {
+          this.send(lines[i]);
+        }
+      }
+
+      if(in_recursion) {
+        return lines.join("\n");
+      }
+    },
+
+    set_delimiters: function(delimiters) {
+      var dels = delimiters.split(" ");
+      this.otag = this.escape_regex(dels[0]);
+      this.ctag = this.escape_regex(dels[1]);
+    },
+
+    escape_regex: function(text) {
+      // thank you Simon Willison
+      if(!arguments.callee.sRE) {
+        var specials = [
+          '/', '.', '*', '+', '?', '|',
+          '(', ')', '[', ']', '{', '}', '\\'
+        ];
+        arguments.callee.sRE = new RegExp(
+          '(\\' + specials.join('|\\') + ')', 'g'
+        );
+      }
+      return text.replace(arguments.callee.sRE, '\\$1');
+    },
+
+    /*
+      find `name` in current `context`. That is find me a value
+      from the view object
+    */
+    find: function(name, context) {
+      name = this.trim(name);
+
+      // Checks whether a value is thruthy or false or 0
+      function is_kinda_truthy(bool) {
+        return bool === false || bool === 0 || bool;
+      }
+
+      var value;
+      if(is_kinda_truthy(context[name])) {
+        value = context[name];
+      } else if(is_kinda_truthy(this.context[name])) {
+        value = this.context[name];
+      }
+
+      if(typeof value === "function") {
+        return value.apply(context);
+      }
+      if(value !== undefined) {
+        return value;
+      }
+      // silently ignore unkown variables
+      return "";
+    },
+
+    // Utility methods
+
+    /* includes tag */
+    includes: function(needle, haystack) {
+      return haystack.indexOf(this.otag + needle) != -1;
+    },
+
+    /*
+      Does away with nasty characters
+    */
+    escape: function(s) {
+      s = String(s === null ? "" : s);
+      return s.replace(/&(?!\w+;)|["'<>\\]/g, function(s) {
+        switch(s) {
+        case "&": return "&amp;";
+        case "\\": return "\\\\";
+        case '"': return '&quot;';
+        case "'": return '&#39;';
+        case "<": return "&lt;";
+        case ">": return "&gt;";
+        default: return s;
+        }
+      });
+    },
+
+    // by @langalex, support for arrays of strings
+    create_context: function(_context) {
+      if(this.is_object(_context)) {
+        return _context;
+      } else {
+        var iterator = ".";
+        if(this.pragmas["IMPLICIT-ITERATOR"]) {
+          iterator = this.pragmas["IMPLICIT-ITERATOR"].iterator;
+        }
+        var ctx = {};
+        ctx[iterator] = _context;
+        return ctx;
+      }
+    },
+
+    is_object: function(a) {
+      return a && typeof a == "object";
+    },
+
+    is_array: function(a) {
+      return Object.prototype.toString.call(a) === '[object Array]';
+    },
+
+    /*
+      Gets rid of leading and trailing whitespace
+    */
+    trim: function(s) {
+      return s.replace(/^\s*|\s*$/g, "");
+    },
+
+    /*
+      Why, why, why? Because IE. Cry, cry cry.
+    */
+    map: function(array, fn) {
+      if (typeof array.map == "function") {
+        return array.map(fn);
+      } else {
+        var r = [];
+        var l = array.length;
+        for(var i = 0; i < l; i++) {
+          r.push(fn(array[i]));
+        }
+        return r;
+      }
+    }
+  };
+
+  return({
+    name: "mustache.js",
+    version: "0.3.1-dev",
+
+    /*
+      Turns a template and view into HTML
+    */
+    to_html: function(template, view, partials, send_fun) {
+      var renderer = new Renderer();
+      if(send_fun) {
+        renderer.send = send_fun;
+      }
+      renderer.render(template, view, partials);
+      if(!send_fun) {
+        return renderer.buffer.join("\n");
+      }
+    }
+  });
+}();

--- a/themes/default/stylesheets/layout.css
+++ b/themes/default/stylesheets/layout.css
@@ -510,3 +510,35 @@ fieldset .help {
 }
 
 /* @end */
+
+/* @group Event Attendees
+----------------------------------------*/
+
+.attendees {
+  overflow: auto;}
+  
+.attendees h3 {
+  display: inline;
+}
+  
+.attendees ul {
+  clear: both;
+  margin: 0;
+  padding: 0;
+  float: left;}
+
+.attendees li {
+  list-style-type: none;
+  float: left; 
+  margin: 0px 8px 8px 0px; 
+  padding: 0; }
+  
+  .attendees li .avatar {
+    width: 50px;
+    height: 50px;
+  }
+
+.plancast-rsvp {
+  font-size: 11px;
+}
+/* @end */


### PR DESCRIPTION
yo calagator overlords,

while hacking across the table from one reid beels today at a #pdxnerdout I added the fetching of plancast attendee avatars for Events that have plancast plan machine tags on them

since plancast doesn't support JSONP, I am routing the requests through my JSONP proxy project: jsonpify.heroku.com

in the event that heroku were to go down, the codez will gracefull fail. jsonpify is just a rack app so if you really wanted to you could mount it as middleware and host it yourself

to test the new functionality out, add the tag: "plancast:plan=145604" to an event
