### PR TITLE
Don't include events in today's event list that expire at midnight today.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -230,7 +230,7 @@ class Event < ActiveRecord::Base
     conditions_sql = <<-HERE
       ( (start_time >= :start_of_range AND start_time <= :end_of_range) OR
         (end_time IS NOT NULL AND
-          NOT (start_time > :end_of_range OR end_time < :start_of_range ) ) )
+          NOT (start_time > :end_of_range OR end_time <= :start_of_range ) ) )
     HERE
 
     conditions_vars = {

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -319,6 +319,11 @@ describe Event do
         :start_time => @tomorrow + 1.day,
         :venue_id => @this_venue.id)
 
+      @started_before_today_and_ends_at_midnight = Event.create!(
+        :title => "Midnight end",
+        :start_time => @yesterday,
+        :end_time => @today_midnight,
+        :venue_id => @this_venue.id)
       @future_events_for_this_venue = @this_venue.find_future_events
     end
 
@@ -345,6 +350,10 @@ describe Event do
 
         it "should not include events that start tomorrow" do
           @overview[:today].should_not include(@starts_and_ends_tomorrow)
+        end
+
+        it "should not include events that ended at midnight today" do
+          @overview[:today].should_not include(@started_before_today_and_ends_at_midnight)
         end
       end
 


### PR DESCRIPTION
Don't include events in today's event list that expire at midnight today.

http://code.google.com/p/calagator/issues/detail?id=432
