### PR TITLE
(#280) Strip whitespace from venue fields

### DIFF
--- a/app/mixins/strip_whitespace.rb
+++ b/app/mixins/strip_whitespace.rb
@@ -1,0 +1,19 @@
+module StripWhitespace
+  def self.included(base)
+    base.extend(ClassMethods)
+  end
+
+  module ClassMethods
+    def strip_whitespace!(*fields)
+      before_validation do |record|
+        fields.each do |field|
+          setter = "#{field}=".to_sym
+          value = record.send(field.to_sym)
+          if value.respond_to?(:strip) and record.respond_to?(setter)
+            record.send(setter, value.strip)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -44,6 +44,7 @@ class Venue < ActiveRecord::Base
   belongs_to :source
 
   # Triggers
+  strip_whitespace! :title, :description, :address, :url, :street_address, :locality, :region, :postal_code, :country, :email, :telephone
   before_validation :normalize_url!
   before_save :geocode
 

--- a/config/initializers/strip_whitespace.rb
+++ b/config/initializers/strip_whitespace.rb
@@ -1,0 +1,4 @@
+require 'strip_whitespace'
+class ActiveRecord::Base
+  include StripWhitespace
+end

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -14,6 +14,25 @@ describe Venue do
     venue.should be_valid
   end
 
+  describe "when validating" do
+    let(:attributes) { {:title => 'My Venue'} }
+    let(:bad_data) { ' blargie ' }
+    let(:expected_data) { bad_data.strip }
+    [:title, :description, :address, :street_address, :locality, :region, :postal_code, :country, :email, :telephone].each do |field|
+      it "should strip whitespace from #{field}" do
+        venue = Venue.new(attributes.merge(field => bad_data))
+        venue.valid?
+        venue.send(field).should == expected_data
+      end
+    end
+
+    it "should strip whitespace from url" do
+      venue = Venue.new(attributes.merge(:url => bad_data))
+      venue.valid?
+      venue.url.should == "http://#{expected_data}"
+    end
+  end
+
 end
 
 describe Venue, "when finding exact duplicates" do


### PR DESCRIPTION
Prior to this commit, Calagator would allow venues to have leading or
trailing spaces persisted in the database, which would lead to venues
having postal codes such as `'97209 '`, thereby reducing the likelihood of
finding duplicates. This commit forcibly strips whitespace from venue
fields during validation by adding `strip_whitespace!` to the
ActiveRecord DSL, technically in the `before_validation` stage.
