### PR TITLE
Support for v3 Google Geocoding API, v2 no longer works, fixes #50

### DIFF
--- a/config/initializers/geokit.rb
+++ b/config/initializers/geokit.rb
@@ -2,6 +2,10 @@ require 'geokit'
 
 # CALAGATOR: Differences from the defaults are tagged like this below.
 
+# remap Google V3 geocoder so we can reference it in provider list, see:
+# https://github.com/geokit/geokit/issues/86
+Geokit::Geocoders::Google3Geocoder = Geokit::Geocoders::GoogleGeocoder3
+
 # These defaults are used in GeoKit::Mappable.distance_to and in acts_as_mappable
 GeoKit::default_units = :miles
 GeoKit::default_formula = :sphere
@@ -67,4 +71,4 @@ GeoKit::Geocoders::geocoder_ca = false
 #
 # CALAGATOR: was [:google, :us], but this is all we need since we're Google-only.
 #
-GeoKit::Geocoders::provider_order = [:google]
+GeoKit::Geocoders::provider_order = [:google3]


### PR DESCRIPTION
For more information, see the following issue on GitHub:
https://github.com/geokit/geokit/issues/86
