### PR TITLE
Upgrade formtastic to 2.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,9 +78,9 @@ gem 'loofah', '1.2.1'
 # NOTE: 'loofah-activerecord' doesn't support Rails 3.2, so use my fork:
 gem 'loofah-activerecord', :git => 'git://github.com/igal/loofah-activerecord.git', :branch => 'with_rails_3.1_and_3.2'
 gem 'bluecloth', '2.2.0'
-gem 'formtastic', '2.0.2' # 2.1 and above change the syntax significantly :(
+gem 'formtastic', '2.2.1'
 # validation_reflection 1.0.0 doesn't support Rails 3.2, so use unofficial patches:
-gem 'validation_reflection', :git => 'git://github.com/ncri/validation_reflection.git', :ref => '60320e6beb088808fd625a8d958dbd0d2661d494'
+#gem 'validation_reflection', :git => 'git://github.com/ncri/validation_reflection.git', :ref => '60320e6beb088808fd625a8d958dbd0d2661d494'
 gem 'acts-as-taggable-on', '2.4.1'
 gem 'jquery-rails', '1.0.19'
 gem 'progress_bar', '1.0.0'

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -127,8 +127,8 @@
       <%= text_field_tag 'trap_field', params[:trap_field] %>
     </li>
   <% end %>
-  <%= f.buttons do %>
-    <%= f.commit_button :label => "Preview", :button_html => {:name => 'preview'} %>
-    <%= f.commit_button %>
+  <%= f.actions do %>
+    <%= f.action :submit, :label => "Preview", :button_html => {:name => 'preview'} %>
+    <%= f.action :submit %>
   <% end %>
 <% end %>

--- a/app/views/sources/edit.html.erb
+++ b/app/views/sources/edit.html.erb
@@ -5,9 +5,7 @@
     <%= f.input :url %>
     <%= f.input :reimport, :label => "Re-import?" %>
   <% end %>
-  <%= f.buttons do %>
-    <%= f.submit "Update" %>
-  <% end %>
+  <%= f.actions :submit %>
 <% end %>
 
 <%= link_to 'Show', @source %> |

--- a/app/views/sources/new.html.erb
+++ b/app/views/sources/new.html.erb
@@ -17,8 +17,8 @@
     <% end %>
   <% end %>
 
-  <%= f.buttons do %>
-    <%= f.commit_button "Import" %>
+  <%= f.actions do %>
+    <%= f.action :submit, :label => "Import" %>
   <% end %>
 
   <%= f.inputs do %>

--- a/app/views/venues/_form.html.erb
+++ b/app/views/venues/_form.html.erb
@@ -52,7 +52,5 @@
     <% end %>
   <% end %>
 
-  <%= f.buttons do %>
-    <%= f.commit_button %>
-  <% end %>
+  <%= f.actions :submit %>
 <% end %>

--- a/themes/default/stylesheets/theme-forms.scss
+++ b/themes/default/stylesheets/theme-forms.scss
@@ -21,7 +21,7 @@ form.formtastic {
   padding-top: .5em;
 }
 
-.formtastic .buttons {
+.formtastic .actions {
   padding-bottom: 3em;
 }
 
@@ -48,7 +48,7 @@ form.formtastic {
   width: 74%;
 }
 
-.formtastic .buttons,
+.formtastic .actions,
 .formtastic .boolean label {
   padding-left: 15%;
 }


### PR DESCRIPTION
We'd been locked on 2.0.2, fearing syntax changes in 2.1. 

As it turns out, these changes were quite minor.
