### PR TITLE
Issue 350 Fix: Prevents past results from showing when user searches for...

### DIFF
--- a/app/views/events/search.html.erb
+++ b/app/views/events/search.html.erb
@@ -4,7 +4,7 @@
   <%= auto_discovery_link_tag(:atom, atom_feed_link(:query => @query, :tag => @tag), :title => "Atom: Search Results for '#{@query}'" )%>
 <% end -%>
 <%= render :partial => 'search_section', :locals => {:description => "current", :events => @grouped_events[:current]} %>
-<%= render :partial => 'search_section', :locals => {:description => "past", :events => @grouped_events[:past]} %>
+<%= render :partial => 'search_section', :locals => {:description => "past", :events => @grouped_events[:past]} if !@current%>
 
 <div id='list_filters' class='sidebar'>
   <h3>Subscribe to</h3>


### PR DESCRIPTION
Simple fix for #350 by checking @current from Events#search in events/search.html.erb before displaying past results. 
