### PR TITLE
Fix Ruby 1.8 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -157,6 +157,7 @@ group :assets do
   gem 'sass', '~> 3.2.14'
   # gem 'coffee-rails', '~> 3.2.1'
 
+  gem 'execjs', '2.0.2'
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   gem 'therubyracer', :platforms => :ruby
 


### PR DESCRIPTION
execjs 2.1.0 started using ruby 1.9-style hash symbol keys, so we need to lock it to 2.0.2 to maintain ruby 1.8 compatibility. This should make Travis green again.

Of course, this raises the question of whether or not we should drop 1.8 support, since its been unsupported for over a year, but that's a whole other kettle of fish. :)
