### PR TITLE
Refactor time_for and set_time_on to private methods

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -147,6 +147,7 @@ class Event < ActiveRecord::Base
     end
     send("#{attribute}_without_smarter_setter=", result)
   end
+  private :set_time_on
 
   # Returns time for the value, which can be a Time, Date, DateTime, String,
   # Array of Strings, nil, etc.
@@ -173,6 +174,7 @@ class Event < ActiveRecord::Base
       raise TypeError, "Unknown type #{value.class.to_s.inspect} with value #{value.inspect}"
     end
   end
+  private :time_for
 
   #---[ Queries ]---------------------------------------------------------
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -218,85 +218,38 @@ describe Event do
 
   end
 
-  describe "#time_for" do
-    before do
-      @date = "2009-01-02"
-      @time = "03:45"
-      @date_time = "#{@date} #{@time}"
-      @value = Time.zone.parse(@date_time)
-      @test_event = Event.new
-    end
-
-    it "should return nil for a NilClass" do
-      @test_event.time_for(nil).should be_nil
-    end
-
-    it "should return time for a String" do
-      @test_event.time_for(@date_time).should eq @value
-    end
-
-    it "should return time for an Array of Strings" do
-      @test_event.time_for([@date, @time]).should eq @value
-    end
-
-    it "should return time for a DateTime" do
-      @test_event.time_for(@value).should eq @value
-    end
-
-    it "should return exception for an invalid date expressed as a String" do
-      lambda { @test_event.time_for("0/0/0") }.should raise_error
-    end
-
-    it "should raise exception for an invalid type" do
-      lambda { @test_event.time_for(Event) }.should raise_error TypeError
-    end
-  end
-
-  describe "#set_time_on" do
+  describe "#start_time=" do
     it "should clear with nil" do
       Event.new(:start_time => nil).start_time.should be_nil
     end
 
     it "should set from date String" do
-      event = Event.new(:start_time => today.to_date.to_s(:db))
-      event.start_time.should be_a_kind_of Time
-      event.start_time.should eq today
+      event = Event.new(:start_time => "2009-01-02")
+      event.start_time.should eq Time.zone.parse("2009-01-02")
     end
 
     it "should set from date-time String" do
-      event = Event.new(:start_time => today.localtime.to_s(:db))
-      event.start_time.should be_a_kind_of Time
-      event.start_time.should eq today
+      event = Event.new(:start_time => "2009-01-02 03:45")
+      event.start_time.should eq Time.zone.parse("2009-01-02 03:45")
+    end
+
+    it "should set from an Array of Strings" do 
+      event = Event.new(:start_time => ["2009-01-03", "02:14"])
+      event.start_time.should eq Time.zone.parse("2009-01-03 02:14")
     end
 
     it "should set from Date" do
-      event = Event.new(:start_time => today.to_date)
-      event.start_time.should be_a_kind_of Time
-      event.start_time.should eq today
+      event = Event.new(:start_time => Date.parse("2009-02-01"))
+      event.start_time.should eq Time.zone.parse("2009-02-01")
     end
 
     it "should set from DateTime" do
-      event = Event.new(:start_time => today.to_datetime)
-      event.start_time.should be_a_kind_of Time
-      event.start_time.should eq today
-    end
-
-    it "should set from TimeWithZone" do
-      event = Event.new(:start_time => ActiveSupport::TimeWithZone.new(Time.now.midnight, Time.zone))
-      event.start_time.should be_a_kind_of Time
-      event.start_time.should eq today
-    end
-
-    it "should set from Time" do
-      time = today
-      event = Event.new(:start_time => time)
-      event.start_time.should be_a_kind_of Time
-      event.start_time.should eq time
+      event = Event.new(:start_time => Time.zone.parse("2009-01-01 05:30"))
+      event.start_time.should eq Time.zone.parse("2009-01-01 05:30")
     end
 
     it "should flag an invalid time" do
-      event = FactoryGirl.build(:event)
-      event.start_time = "1/0"
+      event = Event.new(:start_time => "1/0")
       event.errors[:start_time].should be_present
     end
   end


### PR DESCRIPTION
Hey I noticed that Event.time_for and Event.set_time_on were only used internally within instances of Event. So I changed them from the class level to the instance level, and from public to private. Then moved the tests from time_for to describe "#start_time="
