### PR TITLE
Revert "Fix #updated_at, which may have been breaking iCal refreshes."

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -55,8 +55,6 @@ class Event < ActiveRecord::Base
   include ValidatesBlacklistOnMixin
   validates_blacklist_on :title, :description, :url
 
-  include UpdateUpdatedAtMixin
-
   # Duplicates
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :venue_id

--- a/app/models/update_updated_at_mixin.rb
+++ b/app/models/update_updated_at_mixin.rb
@@ -1,6 +1,0 @@
-# WTF: Rails 3 no longer updates the #updated_at on #save, only on create or through #update_attributes. That's really stupid.
-module UpdateUpdatedAtMixin
-  def self.included(base)
-    base.send:before_save, lambda { |record| record.updated_at = Time.zone.now }
-  end
-end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -61,8 +61,6 @@ class Venue < ActiveRecord::Base
   include ValidatesBlacklistOnMixin
   validates_blacklist_on :title, :description, :address, :url, :street_address, :locality, :region, :postal_code, :country, :email, :telephone
 
-  include UpdateUpdatedAtMixin
-
   # Duplicates
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :closed, :wifi, :access_notes


### PR DESCRIPTION
# updated_at is indeed touched on #save. Just to make sure, I read the source in ActiveRecord, and did a quick test on Event itself.
