### PR TITLE
Refactor date time methods

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -449,10 +449,9 @@ EOF
     (end_time || start_time) >= Time.today
   end
 
-  # Is this event old? Default cutoff is yesterday
-  def old?(cutoff=nil)
-    cutoff ||= Time.zone.now.midnight # midnight today is the end of yesterday
-    (end_time || start_time + 1.hour) <= cutoff
+  # Is this event old?
+  def old?
+    (end_time || start_time + 1.hour) <= Time.zone.now.beginning_of_day
   end
 
   # Did this event start before today but ends today or later?


### PR DESCRIPTION
- `Event#dates` had duplicated arguments, so I refactored with a guard clause and a post-fix conditional to simplify.
- `Event#current?` and `#old?` had default arguments that were not being used. I switched to use `beginning_of_day` for clarity.
