### PR TITLE
Bugfix: Venue#force_geocoding= was always geocoding

### DIFF
--- a/app/controllers/venues_controller.rb
+++ b/app/controllers/venues_controller.rb
@@ -121,7 +121,6 @@ class VenuesController < ApplicationController
   # PUT /venues/1
   # PUT /venues/1.xml
   def update
-    params[:venue][:latitude] = params[:venue][:longitude] = nil if params[:venue][:force_geocoding]=="1" unless params[:venue].blank?
     @venue = Venue.find(params[:id])
     
     if evil_robot = !params[:trap_field].blank?

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -196,8 +196,8 @@ class Venue < ActiveRecord::Base
   end
 
   # Maybe trigger geocoding when we save
-  def force_geocoding=(force_it)
-    self.latitude = self.longitude = nil if force_it
+  def force_geocoding=(value)
+    self.latitude = self.longitude = nil if value == "1"
   end
 
   # Try to geocode, but don't complain if we can't.

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -270,10 +270,20 @@ describe "Venue geocoding" do
     end
   end
 
-  it "should strip location when geocoding is forced" do
-    @venue.force_geocoding=true
-    @venue.latitude.should be_nil
-    @venue.longitude.should be_nil
+  describe "forcing geocoding" do
+    before { @venue.latitude = @venue.longitude = double }
+
+    it "should strip location when geocoding is forced" do
+      @venue.force_geocoding = "1"
+      @venue.latitude.should be_nil
+      @venue.longitude.should be_nil
+    end
+
+    it "should not strip location when geocoding is forced" do
+      @venue.force_geocoding = "0"
+      @venue.latitude.should_not be_nil
+      @venue.longitude.should_not be_nil
+    end
   end
 end
 


### PR DESCRIPTION
An unchecked checkbox in rails sends the value `"0"`, which is truthy, causing `Venue#force_geocoding=` to always force the geocoding. Ideally, I think there'd be some sort of automatic value coercion to boolean going on here, a la Virtus, but for now, let's just fix the bug.

Also, remove a redundant and duplicated version of the same method from the controller, while we're at it.
