### PR TITLE
Bugfix: SECRETS.session_name and .session_secret have no effect

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -116,11 +116,6 @@ module Calagator
 
       # Set timezone for Rails
       config.time_zone = SETTINGS.timezone
-
-
-      # Set cookie session
-      config.session_store :cookie_store, :key => SECRETS.session_name || "calagator"
-      config.secret_token = SECRETS.session_secret
     end
 
     # Set timezone for OS

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Calagator::Application.config.secret_token = '4822c519d5cceb8f4ad7e31bf4801c1d4d98449178d35a7f2bf3725b0aa9aa6d6e1a512b682fb30eb6cab4a92fe24230774004e1564d0386cdad6330065a8b0a'
+Calagator::Application.config.secret_token = SECRETS.session_secret || '4822c519d5cceb8f4ad7e31bf4801c1d4d98449178d35a7f2bf3725b0aa9aa6d6e1a512b682fb30eb6cab4a92fe24230774004e1564d0386cdad6330065a8b0a'

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 
-Calagator::Application.config.session_store :cookie_store, :key => '_calagator_session'
+Calagator::Application.config.session_store :cookie_store, key: SECRETS.session_name || '_calagator_session'
 
 # Use the database for sessions instead of the cookie-based default,
 # which shouldn't be used to store highly confidential information


### PR DESCRIPTION
I was cleaning up `config/application.rb` today, and noticed that in the `before_initialize` block there is the following:

``` ruby
config.session_store :cookie_store, :key => SECRETS.session_name || "calagator"
config.secret_token = SECRETS.session_secret
```

However, there are two initializers: `secret_token.rb` and `session_store.rb` that run immediately after and stomp on these values, effectively making the secret key public, since `secret_token.rb` is on Github. AFAICT this has been the case since the upgrade to Rails 3.0 in 2011. Of course, this isn't really a big deal for Calagator, since there's no authentication. :)

As far as what impact changing the secret key will have on running systems, I believe all existing sessions will just be invalidated, but I'm not 100% on that. I ran some tests, and wasn't actually able to detect any changes when I changed the secret key, but I'm not super familiar with how this system works, to be honest.
