### PR TITLE
Remove broken Get Satisfaction link from header

### DIFF
--- a/themes/default/views/layouts/application.html.erb
+++ b/themes/default/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
         <div id='project_menu'>
           <strong>Get Involved:</strong> <%= link_to "Blog", "http://calagator.wordpress.com/", {:class => 'first'} %> | <%= link_to "Forum", "http://groups.google.com/group/pdx-tech-calendar/" %> | <%= link_to "Code", "https://github.com/calagator/calagator" %>
           <br />
-          <strong>Something not right?</strong> <%= link_to "File an issue", "https://github.com/calagator/calagator/issues" %> or <%= link_to "get satisfaction", 'http://getsatisfaction.com/calagator' %>.
+          <strong>Something not right?</strong> <%= link_to "File an issue", "https://github.com/calagator/calagator/issues" %>
         </div>
         <%= form_tag '/events/search', :method => :get do %>
           <div id='search_form'>


### PR DESCRIPTION
I guess the other way to resolve this would be to recreate the Get Satisfaction account, but that is outside of my powers, hence this PR.
