### PR TITLE
Load both will_paginate and will_paginate/array on boot.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ gem 'htmlentities', '4.3.1'
 gem 'paper_trail', '2.7.2'
 gem 'ri_cal', '0.8.8'
 gem 'rubyzip', '0.9.9', :require =>  'zip/zip'
-gem 'will_paginate', '3.0.5', require: 'will_paginate/array'
+gem 'will_paginate', '3.0.5', require: ['will_paginate', 'will_paginate/array']
 gem 'httparty', '0.11.0'
 gem 'loofah', '1.2.1'
 gem 'loofah-activerecord', '1.1.0'


### PR DESCRIPTION
This was my bad. I thought that requiring 'will_paginate/array' yielded a behaviorial superset of just requiring 'will_paginate', but it turns out that it does not load the railtie. Fixes #139.
