### PR TITLE
Fix sunspot tests run with sql search engine

### DIFF
--- a/spec/models/event_search_spec.rb
+++ b/spec/models/event_search_spec.rb
@@ -71,7 +71,12 @@ describe Event do
   end
 
   describe "Sql" do
-    # spec_helper defaults all tests to sql
+    around do |example|
+      original = Event::SearchEngine.kind
+      Event::SearchEngine.kind = :sql
+      example.run
+      Event::SearchEngine.kind = original
+    end
 
     it_should_behave_like "#search"
 
@@ -97,8 +102,10 @@ describe Event do
       end
 
       if server_running
-        Event::SearchEngine.kind = Venue::SearchEngine.kind = :sunspot
+        original = Event::SearchEngine.kind
+        Event::SearchEngine.kind = :sunspot
         example.run
+        Event::SearchEngine.kind = original
       else
         pending "Solr not running. Start with `rake sunspot:solr:start RAILS_ENV=test`"
       end

--- a/spec/models/venue_search_spec.rb
+++ b/spec/models/venue_search_spec.rb
@@ -88,8 +88,10 @@ describe Venue do
       end
 
       if server_running
-        Event::SearchEngine.kind = Venue::SearchEngine.kind = :sunspot
+        original = Venue::SearchEngine.kind
+        Venue::SearchEngine.kind = :sunspot
         example.run
+        Venue::SearchEngine.kind = original
       else
         pending "Solr not running. Start with `rake sunspot:solr:start RAILS_ENV=test`"
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,9 +83,4 @@ RSpec.configure do |config|
     # a real object. This is generally recommended.
     # mocks.verify_partial_doubles = true
   end
-
-  # Reset to the Sql search engine before each test.
-  config.before(:each) do
-    Event::SearchEngine.kind = Venue::SearchEngine.kind = :sql
-  end
 end


### PR DESCRIPTION
Commit c14fea9 introduced a regression where `SearchEngine.kind` was always `:sql` in the Sunspot tests. I've reverted that commit and added assertions to prevent the regression in the future.

@bryanstearns Even though I reverted your commit, I'm not in love with the strategy I employed to switch the search engine around in the specs, so please feel free to revisit that area once this PR is merged and the assertions are in place.
