### PR TITLE
Remove uncalled Event#to_hcal and associated test

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -233,18 +233,6 @@ class Event < ActiveRecord::Base
     event
   end
 
-  # Returns an hCalendar string representing this Event.
-  def to_hcal
-    <<-EOF
-<div class="vevent">
-<a class="url" href="#{url}">#{url}</a>
-<span class="summary">#{title}</span>:
-<abbr class="dtstart" title="#{start_time.to_s(:yyyymmdd)}">#{start_time.to_s(:long_date).gsub(/\b[0](\d)/, '\1')}</abbr>,
-at the <span class="location">#{venue_title}</span>
-</div>
-EOF
-  end
-
   # Returns an iCalendar string representing this Event.
   #
   # Options:

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -106,12 +106,6 @@ describe Event do
       Event.from_abstract_event(abstract_event).should eq event
     end
 
-    it "should parse an Event into an hCalendar" do
-      actual_hcal = @basic_event.to_hcal
-      pattern = Regexp.new(@basic_hcal.gsub(/\s+/, '\s+')) # Ignore spacing changes
-      actual_hcal.should match pattern
-    end
-
     it "should parse an Event into an iCalendar" do
       actual_ical = @basic_event.to_ical
 


### PR DESCRIPTION
I was going to extract it, but turns out this functionality existed in a view template already!
