### PR TITLE
Refactor SourcesController

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -3,16 +3,13 @@ class SourcesController < ApplicationController
   # POST /import.xml
   def import
     @importer = Source::Importer.new(params[:source])
-    @source = @importer.source
-    @events = @importer.events
-
     respond_to do |format|
-      if @importer.events?
+      if @importer.import
         format.html { redirect_to events_path, flash: { success: render_to_string } }
-        format.xml  { render xml: @source, events: @events }
+        format.xml  { render xml: @importer.source, events: @importer.events }
       else
-        format.html { render action: "new"; flash[:failure] = @importer.failure_message }
-        format.xml  { render xml: @source.errors, status: :unprocessable_entity }
+        format.html { redirect_to new_event_path(url: @importer.source.url), flash: { failure: @importer.failure_message } }
+        format.xml  { render xml: @importer.source.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/views/sources/import.html.erb
+++ b/app/views/sources/import.html.erb
@@ -1,10 +1,10 @@
-<p>Imported <%= @events.size %> entries:</p>
+<p>Imported <%= @importer.events.size %> entries:</p>
 <ul>
-  <% @events.take(5).each do |event| %>
+  <% @importer.events.take(5).each do |event| %>
     <li><%= link_to event.title, event_url(event) %></li>
   <% end %>
-  <% if @events.size > 5 %>
-    <li>And <%= @events.size - 5 %> other events.</li>
+  <% if @importer.events.size > 5 %>
+    <li>And <%= @importer.events.size - 5 %> other events.</li>
   <% end %>
 </ul>
 

--- a/spec/controllers/sources_controller_spec.rb
+++ b/spec/controllers/sources_controller_spec.rb
@@ -36,7 +36,6 @@ describe SourcesController do
       render_views
 
       it "should save the source object when creating events" do
-
         @source.should_receive(:save!)
         post :import, :source => {:url => @source.url}
         flash[:success].should match /Imported/i


### PR DESCRIPTION
Most notably: extract Source::Importer from overly-complex SourcesController#index.
