### PR TITLE
Use ascending order for event sorting

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -41,6 +41,7 @@ These people have contributed to Calagator's design and implementation:
   * Maureen Dugan
   * Micah Geisel
   * Michael Bunsen
+  * Michael Xavier
   * Paige Saez
   * Pam Selle
   * Patrick McSweeny

--- a/app/models/event/search_engine/apache_sunspot.rb
+++ b/app/models/event/search_engine/apache_sunspot.rb
@@ -63,7 +63,7 @@ class Event < ActiveRecord::Base
         Event.solr_search do
           keywords query, minimum_match: 1
           order_by *order
-          order_by :start_time, :desc
+          order_by :start_time, :asc
           with :duplicate, false
           data_accessor_for(Event).include = [:venue]
 
@@ -75,7 +75,7 @@ class Event < ActiveRecord::Base
       def order
         case opts[:order].try(:to_sym)
         when :date
-          [:start_time, :desc]
+          [:start_time, :asc]
         when :venue, :location
           [:venue_title, :asc]
         when :name, :title

--- a/app/models/event/search_engine/sql.rb
+++ b/app/models/event/search_engine/sql.rb
@@ -76,7 +76,7 @@ class Event < ActiveRecord::Base
         when :location, :venue
           'LOWER(venues.title) ASC'
         else
-          'events.start_time DESC'
+          'events.start_time ASC'
         end
         @scope = @scope.order(order)
         self

--- a/spec/models/event_search_spec.rb
+++ b/spec/models/event_search_spec.rb
@@ -39,10 +39,10 @@ describe Event do
       Event.search("zomg").should == [event2]
     end
 
-    it "sorts by start time descending" do
+    it "sorts by start time ascending" do
       event2 = FactoryGirl.create(:event, start_time: 1.day.ago)
       event1 = FactoryGirl.create(:event, start_time: 1.day.from_now)
-      Event.search("").should == [event1, event2]
+      Event.search("").should == [event2, event1]
     end
 
     it "can sort by event title" do
@@ -61,7 +61,7 @@ describe Event do
       event1 = FactoryGirl.create(:event, start_time: 1.year.ago)
       event2 = FactoryGirl.create(:event, start_time: Time.zone.today)
       event3 = FactoryGirl.create(:event, start_time: 1.year.from_now)
-      Event.search("", skip_old: true).should == [event3, event2]
+      Event.search("", skip_old: true).should == [event2, event3]
     end
 
     it "can limit number of events" do


### PR DESCRIPTION
I struggle to think of a case where you would want to see the futuremost
events first and close by events last. If there's a valid case for this,
let me know and I can look at making this more granular.

This resolves #165
