### PR TITLE
Narrow results instead of expand results

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,7 @@ These people have contributed to Calagator's design and implementation:
   * Daniel Etra
   * Daniel Hedlund
   * Don Park
+  * Donald Plummer
   * Ed Borasky
   * Gabrielle Roth
   * Igal Koshevoy

--- a/app/models/event/search_engine/apache_sunspot.rb
+++ b/app/models/event/search_engine/apache_sunspot.rb
@@ -61,7 +61,7 @@ class Event < ActiveRecord::Base
 
       def search(current)
         Event.solr_search do
-          keywords query, minimum_match: 1
+          keywords query
           order_by *order
           order_by :start_time, :desc
           with :duplicate, false

--- a/app/models/event/search_engine/sql.rb
+++ b/app/models/event/search_engine/sql.rb
@@ -57,11 +57,12 @@ class Event < ActiveRecord::Base
       end
 
       def keywords
-        query_conditions = query.split.inject(@scope) do |query_conditions, keyword|
+        query_conditions = @scope.where('LOWER(events.title) LIKE ?', "%#{query.downcase}%")
+          .where('LOWER(events.description) LIKE ?', "%#{query.downcase}%")
+
+        query_conditions = query.split.inject(query_conditions) do |query_conditions, keyword|
           like = "%#{keyword.downcase}%"
           query_conditions
-            .where(['LOWER(events.title) LIKE ?', like])
-            .where(['LOWER(events.description) LIKE ?', like])
             .where(['LOWER(events.url) LIKE ?', like])
             .where(['LOWER(tags.name) = ?', keyword])
         end

--- a/app/models/venue/search_engine/sql.rb
+++ b/app/models/venue/search_engine/sql.rb
@@ -23,13 +23,14 @@ class Venue < ActiveRecord::Base
       end
 
       def keywords
-        query_conditions = query.split.inject(@scope) do |query_conditions, keyword|
-          like = "%#{keyword.downcase}%"
-          query_conditions
-            .where(['LOWER(title) LIKE ?', like])
-            .where(['LOWER(description) LIKE ?', like])
-            .where(['LOWER(tags.name) = ?', keyword])
+        query_conditions = @scope
+          .where(['LOWER(title) LIKE ?', "%#{query.downcase}%"])
+          .where(['LOWER(description) LIKE ?', "%#{query.downcase}%"])
+
+        query_conditions = query.split.inject(query_conditions) do |query_conditions, keyword|
+          query_conditions.where(['LOWER(tags.name) = ?', keyword])
         end
+
         @scope = @scope.where(query_conditions.where_values.join(' OR '))
         self
       end

--- a/spec/models/event_search_spec.rb
+++ b/spec/models/event_search_spec.rb
@@ -26,11 +26,11 @@ describe Event do
       Event.search("omg").should == [event2]
     end
 
-    it "searches multiple terms" do
+    it "does not search multiple terms" do
       event1 = FactoryGirl.create(:event, title: "wtf")
       event2 = FactoryGirl.create(:event, title: "zomg!")
       event3 = FactoryGirl.create(:event, title: "bbq")
-      Event.search("wtf zomg").should =~ [event1, event2]
+      Event.search("wtf zomg").should =~ []
     end
 
     it "searches case-insensitively" do
@@ -75,6 +75,13 @@ describe Event do
       event3 = FactoryGirl.create(:event, title: "omg", start_time: 1.year.from_now)
       event4 = FactoryGirl.create(:event, title: "omg", start_time: 1.year.from_now)
       Event.search("omg", limit: 1).to_a.count.should == 2
+    end
+
+    it "ANDs terms together to narrow search results" do
+      event1 = FactoryGirl.create(:event, title: "women who hack")
+      event2 = FactoryGirl.create(:event, title: "women who bike")
+      event3 = FactoryGirl.create(:event, title: "omg")
+      Event.search("women who hack").should == [event1]
     end
   end
 

--- a/spec/models/venue_search_spec.rb
+++ b/spec/models/venue_search_spec.rb
@@ -60,6 +60,19 @@ describe Venue do
       2.times { FactoryGirl.create(:venue) }
       Venue.search("", limit: 1).count.should == 1
     end
+
+    it "does not search multiple terms" do
+      venue2 = FactoryGirl.create(:venue, title: "zomg")
+      venue1 = FactoryGirl.create(:venue, title: "omg")
+      Venue.search("zomg omg").should == []
+    end
+
+    it "ANDs terms together to narrow search results" do
+      venue2 = FactoryGirl.create(:venue, title: "zomg omg")
+      venue1 = FactoryGirl.create(:venue, title: "zomg cats")
+      Venue.search("zomg omg").should == [venue2]
+    end
+
   end
 
   describe "Sql" do


### PR DESCRIPTION
This changes the queries to AND instead of OR for each word used.

For issue calagator/calagator#140
