### PR TITLE
Fix return value of Source::Importer#import

### DIFF
--- a/app/models/source/importer.rb
+++ b/app/models/source/importer.rb
@@ -7,6 +7,9 @@ class Source < ActiveRecord::Base
     def import
       return unless source.valid?
       self.events = source.create_events!
+
+      self.events.present?
+
     rescue SourceParser::NotFound
       add_error "No events found at remote site. Is the event identifier in the URL correct?"
     rescue SourceParser::HttpAuthenticationRequiredError


### PR DESCRIPTION
In SourcesController#import, we rely on the return value of this method
to determine the success or failure of the import. In cases where the
parsing was successful, but no events were found, we were returning a
truthy empty array.

I checked all the error cases when reviewing #181, but missed the success-but-no-events case.
