### PR TITLE
viewport user-scalable options are 'yes' or 'no'.

### DIFF
--- a/themes/default/views/layouts/application.html.erb
+++ b/themes/default/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
       <%= "#{@page_title} » " if @page_title -%>
       <%= SETTINGS.name -%>: <%= SETTINGS.tagline -%>
     </title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=true">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <link rel='search' type='application/opensearchdescription+xml' href='/opensearch.xml' title='<%= SETTINGS.name %>' />


### PR DESCRIPTION
Fixes warning when running acceptance tests:

```
Viewport argument value "true" for key "user-scalable" not recognized. Content ignored.
```

Reference: http://dev.w3.org/csswg/css-device-adapt/#translation-into-atviewport-descriptors
