### PR TITLE
Use 'git status' to confirm you are in a git repository.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,5 +61,6 @@ These people have contributed to Calagator's design and implementation:
   * Ted Kubaska
   * Ward Cunningham
   * [yves_guillou](http://openclipart.org/user-detail/yves_guillou)
+  * Garrison Jensen
 
 Facilities for many code sprints were generously donated by [Cubespace](http://cubespacepdx.com/), "an innovative workspace community in Portland, Oregon. We provide work stations, meeting rooms, and big office amenities to people who would otherwise be working from their homes, coffee shops, or wherever they can set up their laptops or use their cell phones"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
 
   def self.source_code_version_raw
     # Return a string describing the source code version being used
-    return "" unless system("which git")
+    return "" unless system("git status")
     " - Git timestamp: #{`git log -1 --format=format:"%ad" 2>&1`}"
   rescue Errno::ENOENT
     # Fail quietly if that didn't work; we don't want to get in the way.


### PR DESCRIPTION
This will remove the "- Git timestamp: fatal: Not a git repository (or any of the parent directories): .git " error from the footer. 
