### PR TITLE
Rework Travis config file to get Rubinius working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,27 @@
 language: ruby
+rvm:
+  #- 1.9.3
+  #- 2.0.0
+  #- 2.1.0
+  - rbx-2
 matrix:
-  include:
-    - rvm: 1.9.3
-    - rvm: 2.0.0
-    - rvm: 2.1.0
-    - rvm: rbx-2
-      env: BUNDLE_JOBS=1
   allow_failures:
     - rvm: rbx-2
+  exclude:
+    - rvm: rbx-2
+      env: BUNDLE_JOBS=4
+  include:
+    - rvm: rbx-2
+      env: BUNDLE_JOBS=1
+
+install: bundle install --retry=3
 
   ## JRuby is not compatible, see Gemfile for details.
   # - jruby-19mode
   # - jruby-head
 env:
+  global:
+    - BUNDLE_JOBS=4
   matrix:
     - DB=mysql
     - DB=postgresql
@@ -28,3 +37,4 @@ before_script:
 script:
   - bundle exec rake spec --trace
 cache: bundler
+


### PR DESCRIPTION
Right now Travis can't handle more than 1 job when bundling with
Rubinius. Setting to 1 will get it through and the specs may still fail
later.
