### PR TITLE
simplify Event#url normalization.

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -104,8 +104,7 @@ class Event < ActiveRecord::Base
   end
 
   def url=(value)
-    value = "http://#{value}" unless value.blank? || value.include?("://")
-    super
+    super UrlPrefixer.prefix(value)
   end
 
   # Set the start_time to the given +value+, which could be a Time, Date,

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -141,8 +141,7 @@ class Venue < ActiveRecord::Base
   #===[ Overrides ]=======================================================
 
   def url=(value)
-    value = "http://#{value}" unless value.blank? || value.include?("://")
-    super
+    super UrlPrefixer.prefix(value)
   end
 
   #===[ Address helpers ]=================================================

--- a/lib/url_prefixer.rb
+++ b/lib/url_prefixer.rb
@@ -1,0 +1,9 @@
+class UrlPrefixer
+  def self.prefix(value)
+    if value.blank? || value.include?("://")
+      value
+    else
+      "http://#{value.lstrip}"
+    end
+  end
+end

--- a/spec/lib/url_prefixer_spec.rb
+++ b/spec/lib/url_prefixer_spec.rb
@@ -1,0 +1,29 @@
+require "spec_helper"
+require "url_prefixer"
+
+describe UrlPrefixer do
+  it "adds an http prefix to urls missing it" do
+    url = UrlPrefixer.prefix("google.com")
+    url.should == "http://google.com"
+  end
+
+  it "leaves urls with an existing scheme alone" do
+    url = UrlPrefixer.prefix("https://google.com")
+    url.should == "https://google.com"
+  end
+
+  it "leaves blank urls alone" do
+    url = UrlPrefixer.prefix(" ")
+    url.should == " "
+  end
+
+  it "leaves nil urls alone" do
+    url = UrlPrefixer.prefix(nil)
+    url.should == nil
+  end
+
+  it "avoids whitespace inside url" do
+    url = UrlPrefixer.prefix(" google.com ")
+    url.should == "http://google.com "
+  end
+end


### PR DESCRIPTION
Back at it with a simple little refactoring, here.
- Avoids magical AR lifecycle hooks
- Increases locality
- Only runs when url is set
- Replaces regex with semantically-identical and easier-to-grok #include? statement.

Well... nearly identical. Strings starting with "://" will match now, and they wouldn't before. Close enough. ;)
