### PR TITLE
avoid spamming stdout and stderr when checking for git presence.

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -34,7 +34,7 @@ module ApplicationHelper
 
   def self.source_code_version_raw
     # Return a string describing the source code version being used
-    return "" unless system("git status")
+    return "" unless system("git status 2>&1 >/dev/null")
     " - Git timestamp: #{`git log -1 --format=format:"%ad" 2>&1`}"
   rescue Errno::ENOENT
     # Fail quietly if that didn't work; we don't want to get in the way.


### PR DESCRIPTION
This was spamming the terminal with git status every test run. We just care about the status code, so we can toss the output.
