### PR TITLE
Use Webmock to isolate tests from the network

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ group :development, :test do
   gem 'rspec-its'
   gem 'rspec-rails', '~> 3'
   gem 'rspec-collection_matchers'
+  gem 'webmock', '~> 1.20'
   gem 'capybara', '2.4.3'
   gem 'factory_girl_rails'
   gem 'timecop', '~> 0.7'

--- a/app/models/source_parser.rb
+++ b/app/models/source_parser.rb
@@ -15,8 +15,6 @@ class SourceParser
   # * :url - URL string to read as parser input.
   # * :content - String to read as parser input.
   def self.to_events(opts)
-    opts[:content] = content_for(opts)
-
     # start with the parser that matches the given URL
     matched_parsers = parsers.sort_by do |parser|
       match = parser.url_pattern.present? && opts[:url].try(:match, parser.url_pattern)

--- a/app/models/source_parser.rb
+++ b/app/models/source_parser.rb
@@ -41,11 +41,6 @@ class SourceParser
     self.parsers.map(&:label).map(&:to_s).sort_by(&:downcase)
   end
 
-  # Return content for the arguments
-  def self.content_for(*args)
-    ::SourceParser::Base.content_for(*args).to_s.strip
-  end
-
   # Return content for a URL
   def self.read_url(*args)
     ::SourceParser::Base.read_url(*args)

--- a/app/models/source_parser/base.rb
+++ b/app/models/source_parser/base.rb
@@ -34,11 +34,6 @@ class SourceParser
       self._url_pattern
     end
 
-    # Returns content from either the :content option or by reading a :url.
-    def self.content_for(opts)
-      content = self.read_url(opts[:url])
-    end
-
     # Returns content read from a URL. Easier to stub.
     def self.read_url(url)
       uri = URI.parse(url)
@@ -50,7 +45,7 @@ class SourceParser
           path_and_query += "?#{uri.query}" if uri.query
           request = Net::HTTP::Get.new(path_and_query)
           request.basic_auth(uri.user, uri.password)
-          response = SourceParser::Base::http_response_for(http, request)
+          response = http.request(request)
           raise SourceParser::HttpAuthenticationRequiredError.new if response.code == "401"
           response.body
         else
@@ -59,11 +54,6 @@ class SourceParser
       else
         open(url) { |h| h.read }
       end
-    end
-
-    # Return the HTTPResponse for the +http+ connection and the +request+.
-    def self.http_response_for(http, request)
-      return http.request(request)
     end
 
     # Stub which makes sure that subclasses of Base implement the #parse method.

--- a/app/models/source_parser/base.rb
+++ b/app/models/source_parser/base.rb
@@ -36,12 +36,7 @@ class SourceParser
 
     # Returns content from either the :content option or by reading a :url.
     def self.content_for(opts)
-      content = opts[:content] || self.read_url(opts[:url])
-      if content.respond_to?(:content_type) && ["application/atom+xml"].include?(content.content_type)
-        CGI::unescapeHTML(content.to_str)
-      else
-        content
-      end
+      content = self.read_url(opts[:url])
     end
 
     # Returns content read from a URL. Easier to stub.

--- a/app/models/source_parser/hcal.rb
+++ b/app/models/source_parser/hcal.rb
@@ -13,7 +13,7 @@ class SourceParser
     # * :url => URL String to read events from.
     # * :content => String of data to read events from 
     def self.to_hcals(opts={})
-      content = content_for(opts)
+      content = read_url(opts[:url])
       something = hCalendar.find(:text => content)
       something.is_a?(hCalendar) ? [something] : something
     end

--- a/app/models/source_parser/ical.rb
+++ b/app/models/source_parser/ical.rb
@@ -59,7 +59,7 @@ class SourceParser # :nodoc:
       opts[:skip_old] = true unless opts[:skip_old] == false
       cutoff = Time.now.yesterday
 
-      content = content_for(opts).gsub(/\r\n/, "\n")
+      content = read_url(opts[:url]).gsub(/\r\n/, "\n")
       content = munge_gmt_dates(content)
 
       return [].tap do |events|

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -88,9 +88,11 @@ describe Event, :type => :model do
     end
 
     it "should parse an iCalendar into an Event" do
+      url = "http://foo.bar/"
       actual_ical = Event::IcalRenderer.render(@basic_event)
+      stub_request(:get, url).to_return(body: actual_ical)
 
-      events = SourceParser.to_events(content: actual_ical, skip_old: false)
+      events = SourceParser.to_events(url: url, skip_old: false)
 
       expect(events.size).to eq 1
       event = events.first
@@ -105,8 +107,10 @@ describe Event, :type => :model do
       generated_url = "http://foo.bar/"
       @basic_event.url = nil
       actual_ical = Event::IcalRenderer.render(@basic_event, :url_helper => lambda{|event| generated_url})
+      url = "http://foo.bar/"
+      stub_request(:get, url).to_return(body: actual_ical)
 
-      events = SourceParser.to_events(:content => actual_ical, :skip_old => false)
+      events = SourceParser.to_events(url: url, skip_old: false)
 
       expect(events.size).to eq 1
       event = events.first

--- a/spec/models/source_parser_facebook_spec.rb
+++ b/spec/models/source_parser_facebook_spec.rb
@@ -4,10 +4,11 @@ describe SourceParser::Facebook, :type => :model do
 
   describe "when importing an event" do
     before(:each) do
-      content = read_sample('facebook.json')
-      parsed_content = MultiJson.decode(content)
-      expect(HTTParty).to receive(:get).and_return(parsed_content)
-      @events = SourceParser::Facebook.to_events(:url => 'http://facebook.com/event.php?eid=247619485255249')
+      url = 'http://facebook.com/event.php?eid=247619485255249'
+      graph_url = "http://graph.facebook.com/247619485255249"
+      stub_request(:get, url)
+      stub_request(:get, graph_url).to_return(body: read_sample('facebook.json'), headers: { content_type: "application/json" })
+      @events = SourceParser::Facebook.to_events(url: url)
       @event = @events.first
     end
 

--- a/spec/models/source_parser_facebook_spec.rb
+++ b/spec/models/source_parser_facebook_spec.rb
@@ -6,7 +6,6 @@ describe SourceParser::Facebook, :type => :model do
     before(:each) do
       url = 'http://facebook.com/event.php?eid=247619485255249'
       graph_url = "http://graph.facebook.com/247619485255249"
-      stub_request(:get, url)
       stub_request(:get, graph_url).to_return(body: read_sample('facebook.json'), headers: { content_type: "application/json" })
       @events = SourceParser::Facebook.to_events(url: url)
       @event = @events.first

--- a/spec/models/source_parser_hcal_spec.rb
+++ b/spec/models/source_parser_hcal_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 describe SourceParser::Hcal, "with hCalendar events", :type => :model do
   it "should parse hcal" do
-    hcal_content = read_sample('hcal_single.xml')
-    hcal_source = Source.new(:title => "Calendar event feed", :url => "http://mysample.hcal/")
-    expect(SourceParser::Base).to receive(:read_url).and_return(hcal_content)
+    url = "http://mysample.hcal/"
+    stub_request(:get, url).to_return(body: read_sample('hcal_single.xml'))
+    hcal_source = Source.new(title: "Calendar event feed", url: url)
 
     events = hcal_source.to_events
 
@@ -22,19 +22,19 @@ describe SourceParser::Hcal, "with hCalendar events", :type => :model do
   end
 
   it "should strip html from the venue title" do
-    hcal_content = read_sample('hcal_upcoming_v1.html')
-    hcal_source = Source.new(:title => "Calendar event feed", :url => "http://mysample.hcal/")
-    allow(SourceParser::Base).to receive(:read_url).and_return(hcal_content)
+    url = "http://mysample.hcal/"
+    stub_request(:get, url).to_return(body: read_sample('hcal_upcoming_v1.html'))
+    hcal_source = Source.new(title: "Calendar event feed", url: url)
+
     events = hcal_source.to_events
 
     expect(events.first.venue.title).to eq 'Jive Software Office'
   end
 
   it "should parse a page with multiple events" do
-    hcal_content = read_sample('hcal_multiple.xml')
-
-    hcal_source = Source.new(:title => "Calendar event feed", :url => "http://mysample.hcal/")
-    expect(SourceParser::Base).to receive(:read_url).and_return(hcal_content)
+    url = "http://mysample.hcal/"
+    stub_request(:get, url).to_return(body: read_sample('hcal_multiple.xml'))
+    hcal_source = Source.new(title: "Calendar event feed", url: url)
 
     events = hcal_source.to_events
     expect(events.size).to eq 2
@@ -48,10 +48,10 @@ end
 
 describe SourceParser::Hcal, "with hCalendar to Venue parsing", :type => :model do
   it "should extract an Venue from an hCalendar text" do
-    hcal_upcoming = read_sample('hcal_upcoming_v1.html')
+    url = "http://mysample.hcal/"
+    stub_request(:get, url).to_return(body: read_sample('hcal_upcoming_v1.html'))
 
-    allow(SourceParser::Hcal).to receive(:read_url).and_return(hcal_upcoming)
-    events = SourceParser::Hcal.to_events(:url => "http://foo.bar/")
+    events = SourceParser::Hcal.to_events(url: url)
     event = events.first
     venue = event.venue
 

--- a/spec/models/source_parser_ical_non_standard_spec.rb
+++ b/spec/models/source_parser_ical_non_standard_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe SourceParser::Ical, "when parsing VVENUE", :type => :model do
    before(:each) do
-     @venue = SourceParser::Ical.to_venue(<<-HERE)
+     @venue = SourceParser::Ical.to_venue(%(
 BEGIN:VVENUE
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.
   html
@@ -19,8 +19,7 @@ POSTALCODE:97204
 GEO:45.518798;-122.677583
 URL;X-LABEL=Venue Info:http://eventful.com/V0-001-001423875-1
 CATEGORIES:apple applecom appleinc technology
-END:VVENUE
-    HERE
+END:VVENUE))
   end
 
   it "should have a street_address" do
@@ -43,7 +42,7 @@ end
 describe SourceParser::Ical, "when parsing VCARD lines", :type => :model do
    before(:each) do
      # Note that each line here represents a single, complete property definition -- this method doesn't do any magical unwrapping of text.
-     @vcard_hash = SourceParser::Ical.hash_from_vcard_lines(<<-HERE)
+     @vcard_hash = SourceParser::Ical.hash_from_vcard_lines(%(
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.html
 UID:V0-001-001423875-1@eventful.com
 NAME:Apple Store Pioneer Place
@@ -55,8 +54,7 @@ COUNTRY;;;ABBREV=USA:United States
 POSTALCODE:97204
 GEO:45.518798;-122.677583
 URL;X-LABEL=Venue Info:http://eventful.com/V0-001-001423875-1
-CATEGORIES:apple applecom appleinc technology
-    HERE
+CATEGORIES:apple applecom appleinc technology))
   end
 
   it "should find a property set by its key" do

--- a/spec/models/source_parser_ical_spec.rb
+++ b/spec/models/source_parser_ical_spec.rb
@@ -217,8 +217,8 @@ end
 describe SourceParser::Ical, "when skipping old events", :type => :model do
   before(:each) do
     url = "http://foo.bar/"
-    stub_request(:get, url).to_return(body: <<-ICAL)
-BEGIN:VCALENDAR
+    stub_request(:get, url).to_return(body:
+%(BEGIN:VCALENDAR
 X-WR-CALNAME;VALUE=TEXT:NERV
 VERSION:2.0
 CALSCALE:GREGORIAN
@@ -272,8 +272,7 @@ DTSTART:#{Time.now.strftime("%Y%m%d")}
 DTEND:#{(Time.now-1.year).strftime("%Y%m%d")}
 DTSTAMP:040425
 END:VEVENT
-END:VCALENDAR
-      ICAL
+END:VCALENDAR))
     @source = Source.new(title: "Title", url: url)
   end
 

--- a/spec/models/source_parser_meetup_spec.rb
+++ b/spec/models/source_parser_meetup_spec.rb
@@ -10,7 +10,6 @@ describe SourceParser::Meetup, :type => :model do
       meetup_url = "http://www.meetup.com/pdxpython/events/ldhnqyplbnb/"
       api_url = "https://api.meetup.com/2/event/ldhnqyplbnb?key=foo&sign=true"
 
-      stub_request(:get, meetup_url)
       stub_request(:get, api_url).to_return(body: read_sample('meetup.json'), headers: { content_type: "application/json" })
       @events = SourceParser::Meetup.to_events(url: meetup_url)
       @event = @events.first

--- a/spec/models/source_parser_meetup_spec.rb
+++ b/spec/models/source_parser_meetup_spec.rb
@@ -7,9 +7,12 @@ describe SourceParser::Meetup, :type => :model do
     end
 
     before(:each) do
-      content = read_sample('meetup.json')
-      expect(HTTParty).to receive(:get).and_return(MultiJson.decode(content))
-      @events = SourceParser::Meetup.to_events(:url => 'http://www.meetup.com/pdxpython/events/ldhnqyplbnb/')
+      meetup_url = "http://www.meetup.com/pdxpython/events/ldhnqyplbnb/"
+      api_url = "https://api.meetup.com/2/event/ldhnqyplbnb?key=foo&sign=true"
+
+      stub_request(:get, meetup_url)
+      stub_request(:get, api_url).to_return(body: read_sample('meetup.json'), headers: { content_type: "application/json" })
+      @events = SourceParser::Meetup.to_events(url: meetup_url)
       @event = @events.first
     end
 
@@ -40,10 +43,9 @@ describe SourceParser::Meetup, :type => :model do
     end
 
     before(:each) do
-      expect(SourceParser::Base).to receive(:read_url)
-        .with("http://www.meetup.com/pdxpython/events/ldhnqyplbnb/ical")
-        .and_return(read_sample('meetup.ics'))
-      @events = SourceParser::Meetup.to_events(:url => 'http://www.meetup.com/pdxpython/events/ldhnqyplbnb/')
+      url = "http://www.meetup.com/pdxpython/events/ldhnqyplbnb/ical"
+      stub_request(:get, url).to_return(body: read_sample('meetup.ics'))
+      @events = SourceParser::Meetup.to_events(url: url)
       @event = @events.first
     end
 

--- a/spec/models/source_parser_plancast_spec.rb
+++ b/spec/models/source_parser_plancast_spec.rb
@@ -4,9 +4,12 @@ describe SourceParser::Plancast, :type => :model do
 
   context do
     before(:each) do
-      content = read_sample('plancast.json')
-      expect(HTTParty).to receive(:get).and_return(MultiJson.decode(content))
-      @events = SourceParser::Plancast.to_events(:url => 'http://plancast.com/p/3cos/indiewebcamp')
+      plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
+      api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
+      stub_request(:get, plancast_url)
+      stub_request(:get, api_url).to_return(body: read_sample('plancast.json'), headers: { content_type: "application/json" })
+
+      @events = SourceParser::Plancast.to_events(url: plancast_url)
       @event = @events.first
     end
 
@@ -32,9 +35,11 @@ describe SourceParser::Plancast, :type => :model do
 
   context "with missing venue" do
     before(:each) do
-      content = read_sample('plancast_with_missing_venue.json')
-      expect(HTTParty).to receive(:get).and_return(MultiJson.decode(content))
-      @events = SourceParser::Plancast.to_events(:url => 'http://plancast.com/p/3cos/indiewebcamp')
+      plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
+      api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
+      stub_request(:get, plancast_url)
+      stub_request(:get, api_url).to_return(body: read_sample('plancast_with_missing_venue.json'), headers: { content_type: "application/json" })
+      @events = SourceParser::Plancast.to_events(url: plancast_url)
       @event = @events.first
     end
 

--- a/spec/models/source_parser_plancast_spec.rb
+++ b/spec/models/source_parser_plancast_spec.rb
@@ -6,7 +6,6 @@ describe SourceParser::Plancast, :type => :model do
     before(:each) do
       plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
       api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
-      stub_request(:get, plancast_url)
       stub_request(:get, api_url).to_return(body: read_sample('plancast.json'), headers: { content_type: "application/json" })
 
       @events = SourceParser::Plancast.to_events(url: plancast_url)
@@ -37,7 +36,6 @@ describe SourceParser::Plancast, :type => :model do
     before(:each) do
       plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
       api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
-      stub_request(:get, plancast_url)
       stub_request(:get, api_url).to_return(body: read_sample('plancast_with_missing_venue.json'), headers: { content_type: "application/json" })
       @events = SourceParser::Plancast.to_events(url: plancast_url)
       @event = @events.first

--- a/spec/models/source_parser_spec.rb
+++ b/spec/models/source_parser_spec.rb
@@ -35,7 +35,6 @@ describe SourceParser, "when parsing events", :type => :model do
   it "should use first successful parser's results" do
     events = [double]
 
-    stub_request(:get, "http://www.facebook.com/events/omg")
     stub_request(:get, "http://graph.facebook.com/omg").to_return(body: <<-JSON)
       { "name": "event",
         "start_time": "2010-01-01 12:00:00 UTC",
@@ -185,7 +184,6 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
 
     plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
     api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
-    stub_request(:get, plancast_url)
     stub_request(:get, api_url).to_return(body: read_sample('plancast.json'), headers: { content_type: "application/json" })
 
     source = Source.new(title: "Event with duplicate machine-tagged venue", url: plancast_url)

--- a/spec/models/source_parser_spec.rb
+++ b/spec/models/source_parser_spec.rb
@@ -35,11 +35,12 @@ describe SourceParser, "when parsing events", :type => :model do
   it "should use first successful parser's results" do
     events = [double]
 
-    stub_request(:get, "http://graph.facebook.com/omg").to_return(body: <<-JSON)
-      { "name": "event",
-        "start_time": "2010-01-01 12:00:00 UTC",
-        "end_time": "2010-01-01 13:00:00 UTC" }
-    JSON
+    body = {
+      name: "event",
+      start_time: "2010-01-01 12:00:00 UTC",
+      end_time: "2010-01-01 13:00:00 UTC"
+    }.to_json
+    stub_request(:get, "http://graph.facebook.com/omg").to_return(body: body)
 
     expect(SourceParser.to_events(url: "http://www.facebook.com/events/omg")).to have(1).event
   end
@@ -95,12 +96,12 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
 
     it "an event with a orphaned exact duplicate should should remove duplicate marking" do
       orphan = Event.create!(:title => "orphan", :start_time => Time.parse("July 14 2008"), :duplicate_of_id => 7142008 )
-      cal_content = <<-HERE
+      cal_content = %(
         <div class="vevent">
         <abbr class="summary" title="orphan"></abbr>
         <abbr class="dtstart" title="20080714"></abbr>
         </div>
-      HERE
+      )
       url = "http://mysample.hcal/"
       stub_request(:get, url).to_return(body: cal_content)
 
@@ -118,7 +119,7 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
 
   describe "two identical events with different venues" do
     before(:each) do
-      cal_content = <<-HERE
+      cal_content = %(
         <div class="vevent">
           <abbr class="dtstart" title="20080714"></abbr>
           <abbr class="summary" title="Bastille Day"></abbr>
@@ -129,7 +130,7 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
           <abbr class="summary" title="Bastille Day"></abbr>
           <abbr class="location" title="Bastille"></abbr>
         </div>
-      HERE
+      )
       url = "http://mysample.hcal/"
       stub_request(:get, url).to_return(body: cal_content)
 
@@ -162,13 +163,13 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
       :title => "Squashed Duplicate Venue",
       :duplicate_of_id => master_venue.id)
 
-    cal_content = <<-HERE
+    cal_content = %(
       <div class="vevent">
         <abbr class="dtstart" title="20090117"></abbr>
         <abbr class="summary" title="Event with cloned venue"></abbr>
         <abbr class="location" title="Squashed Duplicate Venue"></abbr>
       </div>
-    HERE
+    )
 
     url = "http://mysample.hcal/"
     stub_request(:get, url).to_return(body: cal_content)

--- a/spec/models/source_parser_spec.rb
+++ b/spec/models/source_parser_spec.rb
@@ -9,12 +9,6 @@ describe SourceParser, "when reading content", :type => :model do
   it "should read from a wacky URL" do
     expect { SourceParser.read_url("not://a.real/~url") }.to raise_error(Errno::ENOENT)
   end
-
-  it "should unescape ATOM feeds" do
-    content = "&lt;atom&gt;"
-    allow(content).to receive(:content_type).and_return("application/atom+xml")
-    expect(SourceParser.content_for(content: content)).to eq "<atom>"
-  end
 end
 
 describe SourceParser, "when subclassing", :type => :model do

--- a/spec/models/source_parser_spec.rb
+++ b/spec/models/source_parser_spec.rb
@@ -2,28 +2,18 @@ require 'spec_helper'
 
 describe SourceParser, "when reading content", :type => :model do
   it "should read from a normal URL" do
-    stub_source_parser_http_response!(:body => 42)
-    expect(SourceParser.read_url("http://a.real/~url")).to eq 42
+    stub_request(:get, "http://a.real/~url").to_return(body: "42")
+    expect(SourceParser.read_url("http://a.real/~url")).to eq "42"
   end
 
   it "should read from a wacky URL" do
-    uri = URI.parse('fake')
-    # please retain space betwen "?" and ")" on following line; it avoids a SciTE issue
-    allow(uri).to receive(:respond_to? ).and_return(false)
-    allow(URI).to receive(:parse).and_return(uri)
-
-    error_type = RUBY_PLATFORM.match(/mswin/) ? Errno::EINVAL : Errno::ENOENT
-    expect { SourceParser.read_url("not://a.real/~url") }.to raise_error(error_type)
+    expect { SourceParser.read_url("not://a.real/~url") }.to raise_error(Errno::ENOENT)
   end
 
   it "should unescape ATOM feeds" do
-    content = "ATOM"
+    content = "&lt;atom&gt;"
     allow(content).to receive(:content_type).and_return("application/atom+xml")
-
-    expect(SourceParser::Base).to receive(:read_url).and_return(content)
-    expect(CGI).to receive(:unescapeHTML).and_return("42")
-
-    expect(SourceParser.content_for(:fake => :argument)).to eq "42"
+    expect(SourceParser.content_for(content: content)).to eq "<atom>"
   end
 end
 
@@ -51,15 +41,14 @@ describe SourceParser, "when parsing events", :type => :model do
   it "should use first successful parser's results" do
     events = [double]
 
-    expect(SourceParser::Facebook).to receive(:to_events).and_return(false)
-    expect(SourceParser::Meetup).to receive(:to_events).and_return(events)
-    expect(SourceParser::Base).to receive(:content_for).and_return("fake content")
+    stub_request(:get, "http://www.facebook.com/events/omg")
+    stub_request(:get, "http://graph.facebook.com/omg").to_return(body: <<-JSON)
+      { "name": "event",
+        "start_time": "2010-01-01 12:00:00 UTC",
+        "end_time": "2010-01-01 13:00:00 UTC" }
+    JSON
 
-    expect(SourceParser::Plancast).not_to receive(:to_events)
-    expect(SourceParser::Hcal).not_to receive(:to_events)
-    expect(SourceParser::Ical).not_to receive(:to_events)
-
-    expect(SourceParser.to_events(:fake => :argument)).to have(1).event
+    expect(SourceParser.to_events(url: "http://www.facebook.com/events/omg")).to have(1).event
   end
 end
 
@@ -67,7 +56,8 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
   describe "with two identical events" do
     before :each do
       @venue_size_before_import = Venue.count
-      @cal_source = Source.new(:title => "Calendar event feed", :url => "http://mysample.hcal/")
+      url = "http://mysample.hcal/"
+      @cal_source = Source.new(title: "Calendar event feed", url: url)
       @cal_content = (%{
       <div class="vevent">
         <abbr class="dtstart" title="20080714"></abbr>
@@ -79,7 +69,7 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
         <abbr class="summary" title="Bastille Day"></abbr>
         <abbr class="location" title="Arc de Triomphe"></abbr>
       </div>})
-      allow(SourceParser::Base).to receive(:read_url).and_return(@cal_content)
+      stub_request(:get, url).to_return(body: @cal_content)
       @events = @cal_source.to_events
       @created_events = @cal_source.create_events!(:skip_old => false)
     end
@@ -99,9 +89,9 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
 
   describe "with an event" do
     it "should retrieve an existing event if it's an exact duplicate" do
-      hcal_source = Source.new(:title => "Calendar event feed", :url => "http://mysample.hcal/")
-      hcal_content = read_sample('hcal_event_duplicates_fixture.xml')
-      allow(SourceParser::Base).to receive(:read_url).and_return(hcal_content)
+      url = "http://mysample.hcal/"
+      hcal_source = Source.new(title: "Calendar event feed", url: url)
+      stub_request(:get, url).to_return(body: read_sample('hcal_event_duplicates_fixture.xml'))
 
       event = hcal_source.to_events.first
       event.save!
@@ -118,9 +108,10 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
         <abbr class="dtstart" title="20080714"></abbr>
         </div>
       HERE
-      allow(SourceParser::Base).to receive(:read_url).and_return(cal_content)
+      url = "http://mysample.hcal/"
+      stub_request(:get, url).to_return(body: cal_content)
 
-      cal_source = Source.new(:title => "Calendar event feed", :url => "http://mysample.hcal/")
+      cal_source = Source.new(title: "Calendar event feed", url: url)
       imported_event = cal_source.create_events!(:skip_old => false).first
       expect(imported_event).not_to be_marked_as_duplicate
     end
@@ -146,9 +137,10 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
           <abbr class="location" title="Bastille"></abbr>
         </div>
       HERE
-      allow(SourceParser::Base).to receive(:read_url).and_return(cal_content)
+      url = "http://mysample.hcal/"
+      stub_request(:get, url).to_return(body: cal_content)
 
-      cal_source = Source.new(:title => "Calendar event feed", :url => "http://mysample.hcal/")
+      cal_source = Source.new(title: "Calendar event feed", url: url)
       @parsed_events  = cal_source.to_events
       @created_events = cal_source.create_events!(:skip_old => false)
     end
@@ -185,11 +177,10 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
       </div>
     HERE
 
-    allow(SourceParser::Base).to receive(:read_url).and_return(cal_content)
+    url = "http://mysample.hcal/"
+    stub_request(:get, url).to_return(body: cal_content)
 
-    source = Source.new(
-      :title => "Event with squashed venue",
-      :url   => "http://IcalEventWithSquashedVenue.com/")
+    source = Source.new(title: "Event with squashed venue", url: url)
 
     event = source.to_events(:skip_old => false).first
     expect(event.venue.title).to eq "Master"
@@ -198,13 +189,12 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
   it "should use an existing venue when importing an event with a matching machine tag that describes a venue" do
     venue = Venue.create!(:title => "Custom Urban Airship", :tag_list => "plancast:place=1520153")
 
-    content = read_sample('plancast.json')
-    allow(SourceParser::Base).to receive(:read_url).and_return("this content doesn't matter")
-    expect(HTTParty).to receive(:get).and_return(MultiJson.decode(content))
+    plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
+    api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
+    stub_request(:get, plancast_url)
+    stub_request(:get, api_url).to_return(body: read_sample('plancast.json'), headers: { content_type: "application/json" })
 
-    source = Source.new(
-      :title => "Event with duplicate machine-tagged venue",
-      :url   => "http://plancast.com/p/3cos/indiewebcamp")
+    source = Source.new(title: "Event with duplicate machine-tagged venue", url: plancast_url)
 
     event = source.to_events(:skip_old => false).first
 
@@ -222,7 +212,7 @@ describe SourceParser, "checking duplicates when importing", :type => :model do
           expect(other_parser).not_to receive :to_events
         end
 
-        allow(SourceParser::Base).to receive(:read_url).and_return("this content doesn't matter")
+        stub_request(:get, url)
         Source.new(:title => parser_name, :url => url).to_events
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,8 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.use_transactional_fixtures = false
-  config.before(:all) do |example|
+
+  config.before(:suite) do |example|
     DatabaseCleaner.clean_with(:truncation)
   end
   config.before(:each) do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,9 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
   config.use_transactional_fixtures = false
+  config.before(:all) do |example|
+    DatabaseCleaner.clean_with(:truncation)
+  end
   config.before(:each) do |example|
     DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,8 @@
+require "webmock/rspec"
+
+RSpec.configure do |config|
+  config.before do
+    # poltergeist requires this
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+end


### PR DESCRIPTION
Replaced all the network-related mocks and stubs with Webmock. This is great, because now our tests know much less about the internals of the objects under test, enabling easier refactoring. Was also able to remove a few methods that only existed as seams for stubbing network responses. Lastly, Webmock exposed an unnecessary http request happening in all parsers, so that was removed, which should increase performance.