### PR TITLE
Add remaining acceptance tests

### DIFF
--- a/spec/features/add_venue_spec.rb
+++ b/spec/features/add_venue_spec.rb
@@ -5,7 +5,8 @@ feature 'Venue Creation' do
 
   scenario 'User adds a new venue' do
 
-    visit '/venues'
+    visit '/'
+    click_on 'Venues'
     click_on 'Add a venue'
 
 

--- a/spec/features/import_events_from_feed_spec.rb
+++ b/spec/features/import_events_from_feed_spec.rb
@@ -1,0 +1,44 @@
+#coding: UTF-8
+require 'rails_helper'
+
+feature 'import events from a feed' do
+  background do
+    Timecop.travel('2010-01-01')
+    stub_request(:get, 'http://even.ts/feed').to_return(body: read_sample('ical_multiple_calendars.ics'))
+  end
+
+  after do
+    Timecop.return
+  end
+
+  scenario 'A user imports an events from a feed' do
+    visit '/'
+    click_on 'Import event(s)'
+
+    fill_in 'URL', with: 'http://even.ts/feed'
+    click_on 'Import'
+
+    expect(find(".flash")).to have_content %(
+      Imported 3 entries:
+
+      Coffee with Jason
+      Coffee with Mike
+      Coffee with Kim
+    )
+
+    expect(page).to have_content 'Viewing 3 future events'
+
+    expect(find(".event_table")).to have_content %(
+      Thursday Apr 8
+
+      Coffee with Jason
+      midnight–1am
+
+      Coffee with Mike
+      midnight–1am
+
+      Coffee with Kim
+      midnight–1am
+    )
+  end
+end

--- a/spec/features/managing_venue_spec.rb
+++ b/spec/features/managing_venue_spec.rb
@@ -1,12 +1,14 @@
 require 'rails_helper'
 
 feature 'Venue Editing' do
-  let(:venue) { create(:venue) }
-  let(:new_venue) { build(:venue) }
+  let!(:venue) { create(:venue) }
+  let!(:event) { create(:event, venue: venue) }
+  let!(:new_venue) { build(:venue) }
 
   scenario 'A user edits an existing venue' do
 
-    visit "/venues/#{venue.id}"
+    visit "/"
+    click_on venue.title
     click_on 'edit'
 
     venue_name = find_field('Venue Name').value

--- a/spec/features/managing_venue_spec.rb
+++ b/spec/features/managing_venue_spec.rb
@@ -44,3 +44,26 @@ feature 'Venue Editing' do
     expect(page).to have_content 'This venue is no longer open for business.' if new_venue.closed
   end
 end
+
+feature 'Venue Deletion' do
+  background do
+    create :venue, title: 'Test Venue'
+  end
+
+  scenario 'A user deletes a venue' do
+    visit '/'
+    click_on 'Venues'
+
+    within '#newest' do
+      click_on 'Test Venue'
+    end
+
+    click_on 'delete'
+
+    expect(page).to have_content %("Test Venue" has been deleted)
+
+    click_on "List all venues"
+
+    expect(page).to have_content "Sorry, there are no venues"
+  end
+end


### PR DESCRIPTION
These acceptance tests should get us to full coverage of the _public_ functionality of Calagator. There are still some areas that are not covered by acceptance tests, but one can only access them by typing in specific urls, AFAICT. 

With these tests in place, I think we can safely start looking at some of the high value tasks, like converting the codebase to an engine, and/or upgrading the version of Rails used.