### PR TITLE
Fix Webmock and Solr race condition

### DIFF
--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,8 +1,8 @@
 require "webmock/rspec"
 
 RSpec.configure do |config|
-  config.before do
-    # poltergeist requires this
+  config.before(:suite) do
+    # poltergeist and solr need to connect to localhost
     WebMock.disable_net_connect!(allow_localhost: true)
   end
 end


### PR DESCRIPTION
Noticed that master is suddenly red, even though PRs were green. Turns out it was a race condition between Webmock allowing localhost connections, and Solr sending a health ping to localhost. Should be fixed now.