### PR TITLE
Drop support for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - rbx-2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ Changes
 List of Calagator stable releases and changes, with the latest at the top:
 
   * [master]
-    * [!] Dropped support for Ruby 1.8.7. Use Ruby 1.9.3+.
+    * [!] Dropped support for Ruby 1.8.7, and 1.9.3. Use Ruby 2.0+.
     * Switched from outdated v2 Google Maps to a more flexible leaflet-based mapping system.
       * [!] New mapping settings have been added to secrets.yml
         If you wish to keep using Google as your map provider, you'll need to set your provider and add an API key to secrets.yml.

--- a/Gemfile
+++ b/Gemfile
@@ -55,10 +55,6 @@ gem 'sunspot_rails', '2.1.1'
 gem 'sunspot_solr',  '2.1.1'
 gem 'lucene_query', '0.1'
 
-platforms :mri_19 do
-  gem 'backports', '3.6.4', require: "backports/2.0.0/enumerable/lazy"
-end
-
 # Some dependencies are only needed for test and development environments. On
 # production servers, you can skip their installation by running:
 #   bundle install --without development:test
@@ -87,7 +83,7 @@ group :development, :test do
     gem 'capistrano-bundler', '1.0.0'
 
     # Guard and plugins
-    platforms :ruby_19, :ruby_20 do
+    platforms :mri do
       gem 'guard', '~> 1.3.0'
       gem 'guard-rspec', '~> 1.2.1'
     end
@@ -106,16 +102,8 @@ group :development, :test do
   #
   #   touch .dev && bundle
   if File.exist?(".dev")
-    platforms :mri_19 do
-      gem 'debugger'
-      gem 'debugger-ruby_core_source'
-    end
-
-    platforms :mri_20, :mri_21 do
+    platforms :mri do
       gem 'byebug'
-    end
-
-    platforms :mri_19, :mri_20, :mri_21 do
       gem 'simplecov'
     end
   end

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ You will need to:
     * [Think Like a Git](http://think-like-a-git.net/)
 
 
-* [Install Ruby](http://www.ruby-lang.org/), a programming language. You can use MRI Ruby 1.9.3+, or Rubinius 2.0+. Your operating system may already have it installed or offer it as a pre-built package. You can check by typing `ruby -v` in your shell or console.
+* [Install Ruby](http://www.ruby-lang.org/), a programming language. You can use MRI Ruby 2.0+, or Rubinius 2.0+. Your operating system may already have it installed or offer it as a pre-built package. You can check by typing `ruby -v` in your shell or console.
 * [Install SQLite3](http://www.sqlite.org/), a database engine. Your operating system may already have it installed or offer it as a pre-built package. You can check by typing `sqlite3 -version` in your shell or console.
 * [Install Bundler](http://gembundler.com/), a Ruby dependency management tool. You should run `gem install bundler` as root or an administrator after installing Ruby.
 * Copy the source code. From your command line, run `git clone https://github.com/calagator/calagator.git`, which will create a `calagator` directory with the source code. Change into this directory (run `cd calagator`) and run the remaining commands from there.

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # --------------------------------------------------------------------------------------------------
 # Please note: If you're subclassing Formtastic::FormBuilder, Formtastic uses
 # class_attribute for these configuration attributes instead of the deprecated

--- a/spec/features/add_event_spec.rb
+++ b/spec/features/add_event_spec.rb
@@ -1,4 +1,3 @@
-#coding: UTF-8
 require 'rails_helper'
 
 feature 'Event Creation' do

--- a/spec/features/import_events_from_feed_spec.rb
+++ b/spec/features/import_events_from_feed_spec.rb
@@ -1,4 +1,3 @@
-#coding: UTF-8
 require 'rails_helper'
 
 feature 'import events from a feed' do

--- a/spec/features/managing_event_spec.rb
+++ b/spec/features/managing_event_spec.rb
@@ -1,4 +1,3 @@
-#coding: UTF-8
 require 'rails_helper'
 
 feature 'Event Editing' do

--- a/vendor/gems/mofo-0.2.8/mofo.gemspec
+++ b/vendor/gems/mofo-0.2.8/mofo.gemspec
@@ -1,6 +1,3 @@
-# -*- encoding: utf-8 -*-
-# stub: mofo 0.2.8 ruby lib
-
 Gem::Specification.new do |s|
   s.name = "mofo"
   s.version = "0.2.8"


### PR DESCRIPTION
Any reason not to do this now, or should we wait for Rails 5?