### PR TITLE
Remove Rubinius from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,11 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - rbx-2
 env:
   matrix:
     - DB=mysql
     - DB=postgresql
     - DB=sqlite
-matrix:
-  allow_failures:
-    - rvm: rbx-2
 
 before_install:
   - ruby ci/copy_database_config.rb

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@ You will need to:
     * [Think Like a Git](http://think-like-a-git.net/)
 
 
-* [Install Ruby](http://www.ruby-lang.org/), a programming language. You can use MRI Ruby 1.9.3+, or Rubinius 2.0+. Your operating system may already have it installed or offer it as a pre-built package. You can check by typing `ruby -v` in your shell or console.
+* [Install Ruby](http://www.ruby-lang.org/), a programming language. You can use MRI Ruby version 1.9.3, 2.0, or 2.1. Your operating system may already have it installed or offer it as a pre-built package. You can check by typing `ruby -v` in your shell or console.
 * [Install SQLite3](http://www.sqlite.org/), a database engine. Your operating system may already have it installed or offer it as a pre-built package. You can check by typing `sqlite3 -version` in your shell or console.
 * [Install Bundler](http://gembundler.com/), a Ruby dependency management tool. You should run `gem install bundler` as root or an administrator after installing Ruby.
 * Copy the source code. From your command line, run `git clone https://github.com/calagator/calagator.git`, which will create a `calagator` directory with the source code. Change into this directory (run `cd calagator`) and run the remaining commands from there.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,13 @@
 require 'factory_girl'
 
-unless RUBY_ENGINE == "rbx" # SimpleCov slows down Rubinius dramatically (using rbx 2.2.6)
-  require 'simplecov'
-  require 'coveralls'
+require 'simplecov'
+require 'coveralls'
 
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter,
-  ]
-  SimpleCov.start('rails')
-end
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+  SimpleCov::Formatter::HTMLFormatter,
+  Coveralls::SimpleCov::Formatter,
+]
+SimpleCov.start('rails')
 
 require "rails_helper"
 


### PR DESCRIPTION
Calgator on Rubinius has been segfaulting on Travis for about six months, but in the `allow_failures` section, so testing Rubinius is merely increasing our Travis CI time by about 50%. Remove for now, hopefully someone can get rbx to work again in a future PR.