### PR TITLE
Ensure test event doesn't cross day boundary by starting it at midnight.

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,7 +23,7 @@ FactoryGirl.define do
   factory :event do
     sequence(:title) { |n| "Event #{n}" }
     sequence(:description) { |n| "Description of Event #{n}." }
-    start_time { Time.now + 1.hour }
+    start_time { today + 1.hour }
     end_time { start_time + 1.hour }
 
     after(:create) { Sunspot.commit if Event::SearchEngine.kind == :sunspot }


### PR DESCRIPTION
Noticed that the tests were suddenly failing, turns out there's a test that always fails at certain times. Fixed.