### PR TITLE
Refactor TimeRange

### DIFF
--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -29,6 +29,8 @@ class TimeRange
     @context_date = context
   end
 
+  attr_reader :start_time, :end_time, :format, :context_date
+
   def to_s
     figure_out_the_general_format
     remove_stuff_implied_by_context
@@ -41,15 +43,15 @@ class TimeRange
     # Assume one date only, equal start/end
     @start_format_list = [nil, :wday, :month, :day, :year, :at, :hour, :min, :suffix, nil]
     
-    @start_details = time_details(@start_time)
-    if @end_time.nil? or @start_time == @end_time
+    @start_details = time_details(start_time)
+    if end_time.nil? or start_time == end_time
       # One date only, or equal dates.
       @end_format_list = @conjunction = nil
     else
-      @end_details = time_details(@end_time)
-      if @start_time.to_date == @end_time.to_date
+      @end_details = time_details(end_time)
+      if start_time.to_date == end_time.to_date
         @start_format_list[@start_format_list.index(:at)] = :from
-        @conjunction = @format == :text ? "-" : "&ndash;"
+        @conjunction = format == :text ? "-" : "&ndash;"
         if @start_details[:suffix] == @end_details[:suffix]
           # same day & am/pm
           # Tuesday, April 1, 2008 from 9-11am
@@ -70,14 +72,14 @@ class TimeRange
   end
     
   def remove_stuff_implied_by_context
-    if @context_date
+    if context_date
       # Do it to both start & end lists
-      [[@start_time, @start_format_list], [@end_time, @end_format_list]].each do |t, list|
+      [[start_time, @start_format_list], [end_time, @end_format_list]].each do |t, list|
         if t and list
-          list.delete(:year) if @context_date.year == t.year # same year
+          list.delete(:year) if context_date.year == t.year # same year
           [:wday, :month, :day, :at, :from].each do |k|
             list.delete(k)
-          end if @context_date == t.to_date
+          end if context_date == t.to_date
         end
       end
     end
@@ -85,14 +87,14 @@ class TimeRange
 
   def combine_the_pieces
     results = []
-    results << %Q|<time class="dtstart dt-start" title="#{@start_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{@start_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if @format == :hcal
+    results << %Q|<time class="dtstart dt-start" title="#{start_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{start_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
     results << format_details_by_list(@start_details, @start_format_list)
-    results << %Q|</time>| if @format == :hcal
+    results << %Q|</time>| if format == :hcal
     if @end_format_list
       results << @conjunction
-      results << %Q|<time class="dtend dt-end" title="#{@end_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{@end_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if @format == :hcal
+      results << %Q|<time class="dtend dt-end" title="#{end_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{end_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
       results << format_details_by_list(@end_details, @end_format_list)
-      results << %Q|</time>| if @format == :hcal
+      results << %Q|</time>| if format == :hcal
     end
     results.join('').html_safe
   end

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -1,4 +1,5 @@
 module TimeRangeHelper
+  extend self
   # Initialize with a single DateTime, a pair of DateTimes,
   # or an object that responds_to start_time and end_time, and two options
   # By default (unless :format => :text) include <abbr> tags for hCalendar,

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -44,10 +44,7 @@ class TimeRange
     @start_format_list = [nil, :wday, :month, :day, :year, :at, :hour, :min, :suffix, nil]
     
     @start_details = time_details(start_time)
-    if end_time.nil? or start_time == end_time
-      # One date only, or equal dates.
-      @end_format_list = @conjunction = nil
-    else
+    if range?
       @end_details = time_details(end_time)
       if start_time.to_date == end_time.to_date
         @start_format_list[@start_format_list.index(:at)] = :from
@@ -70,7 +67,11 @@ class TimeRange
       end
     end
   end
-    
+
+  def range?
+    end_time.present? && start_time != end_time
+  end
+
   def remove_stuff_implied_by_context
     if context_date
       # Do it to both start & end lists
@@ -90,7 +91,7 @@ class TimeRange
     results << %Q|<time class="dtstart dt-start" title="#{start_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{start_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
     results << format_details_by_list(@start_details, @start_format_list)
     results << %Q|</time>| if format == :hcal
-    if @end_format_list
+    if range?
       results << @conjunction
       results << %Q|<time class="dtend dt-end" title="#{end_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{end_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
       results << format_details_by_list(@end_details, @end_format_list)

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -46,9 +46,8 @@ class TimeRange
     @start_details = time_details(start_time)
     if range?
       @end_details = time_details(end_time)
-      if start_time.to_date == end_time.to_date
+      if same_day?
         @start_format_list[@start_format_list.index(:at)] = :from
-        @conjunction = format == :text ? "-" : "&ndash;"
         if @start_details[:suffix] == @end_details[:suffix]
           # same day & am/pm
           # Tuesday, April 1, 2008 from 9-11am
@@ -63,13 +62,29 @@ class TimeRange
         # different days: 
         # Tuesday, April 1, 2008 at 9am through Wednesday, April 1, 2009 at 1:30pm
         @end_format_list = @start_format_list.clone
-        @conjunction = " through "
       end
+    end
+  end
+
+  def conjunction
+    return unless range?
+    if same_day?
+      text_format? ? "-" : "&ndash;"
+    else
+      " through "
     end
   end
 
   def range?
     end_time.present? && start_time != end_time
+  end
+
+  def same_day?
+    start_time.to_date == end_time.to_date
+  end
+
+  def text_format?
+    format == :text
   end
 
   def remove_stuff_implied_by_context
@@ -90,7 +105,7 @@ class TimeRange
     results = []
     results += component(start_time, @start_details, @start_format_list, css_class: "dtstart dt-start")
     if range?
-      results << @conjunction
+      results << conjunction
       results += component(end_time, @end_details, @end_format_list, css_class: "dtend dt-end")
     end
     results.join

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -32,16 +32,18 @@ class TimeRange
   attr_reader :start_time, :end_time, :format, :context_date
 
   def to_s
-    figure_out_the_general_format
     remove_stuff_implied_by_context
     combine_the_pieces
   end
 
   private
 
-  def figure_out_the_general_format
-    @start_details = time_details(start_time)
-    @end_details = time_details(end_time) if range?
+  def start_details
+    @start_details ||= time_details(start_time)
+  end
+
+  def end_details
+    @end_details ||= range? ? time_details(end_time) : {}
   end
 
   def start_format_list
@@ -74,7 +76,7 @@ class TimeRange
   end
 
   def same_meridiem?
-    time_details(start_time)[:suffix] == time_details(end_time)[:suffix]
+    start_details[:suffix] == end_details[:suffix]
   end
 
   def text_format?
@@ -100,7 +102,7 @@ class TimeRange
   end
 
   def start_text
-    component(start_time, @start_details, start_format_list, css_class: "dtstart dt-start")
+    component(start_time, start_details, start_format_list, css_class: "dtstart dt-start")
   end
 
   def conjunction
@@ -114,7 +116,7 @@ class TimeRange
 
   def end_text
     return unless range?
-    component(end_time, @end_details, end_format_list, css_class: "dtend dt-end")
+    component(end_time, end_details, end_format_list, css_class: "dtend dt-end")
   end
 
   def component(time, details, list, css_class: nil)

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -88,16 +88,20 @@ class TimeRange
 
   def combine_the_pieces
     results = []
-    results << %Q|<time class="dtstart dt-start" title="#{start_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{start_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
-    results << format_details_by_list(@start_details, @start_format_list)
-    results << %Q|</time>| if format == :hcal
+    results += component(start_time, @start_details, @start_format_list, css_class: "dtstart dt-start")
     if range?
       results << @conjunction
-      results << %Q|<time class="dtend dt-end" title="#{end_time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{end_time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
-      results << format_details_by_list(@end_details, @end_format_list)
-      results << %Q|</time>| if format == :hcal
+      results += component(end_time, @end_details, @end_format_list, css_class: "dtend dt-end")
     end
-    results.join('').html_safe
+    results.join
+  end
+
+  def component(time, details, list, css_class: nil)
+    results = []
+    results << %Q|<time class="#{css_class}" title="#{time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
+    results << format_details_by_list(details, list)
+    results << %Q|</time>| if format == :hcal
+    results
   end
 
   PREFIXES = {

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -8,11 +8,11 @@ module TimeRangeHelper
       end_time = start_time.end_time
       start_time = start_time.start_time
     end
-    TimeRange.new(start_time, end_time, format: format, context: context).to_s.html_safe
+    TimeRange.new(start_time, end_time, format, context).to_s.html_safe
   end  
 end
 
-class TimeRange
+class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
   # A representation of a time or range of time that can format itself 
   # in a meaningful way. Examples:
   # "Thursday, April 3, 2008"
@@ -22,15 +22,6 @@ class TimeRange
   # "Thursday-Friday, April 3-5, 2008"
   # (context: during 2008) "Thursday April 5, 2009 at 3:30pm through Friday, April 5 at 8:45pm, 2009"
   # (same, context: during 2009) "Thursday April 5 at 3:30pm through Friday, April 5 at 8:45pm"
-  def initialize(start_time, end_time=nil, format: nil, context: nil)
-    @start_time = start_time
-    @end_time = end_time
-    @format = format
-    @context_date = context
-  end
-
-  attr_reader :start_time, :end_time, :format, :context_date
-
   def to_s
     [start_text, conjunction, end_text].compact.join
   end

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -29,7 +29,8 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
   private
 
   def start_text
-    start_parts.to_s(format, "start")
+    parts = TimeParts.new(start_time, context_date, from_prefix: same_day?, no_meridian: same_meridian?)
+    parts.to_s(format, "start")
   end
 
   def conjunction
@@ -43,15 +44,8 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
 
   def end_text
     return unless range?
-    end_parts.to_s(format, "end")
-  end
-
-  def start_parts
-    TimeParts.new(start_time, context_date, from_prefix: same_day?, no_meridian: same_meridian?)
-  end
-
-  def end_parts
-    TimeParts.new(end_time, context_date, time_only: same_day?)
+    parts = TimeParts.new(end_time, context_date, time_only: same_day?)
+    parts.to_s(format, "end")
   end
 
   def range?
@@ -122,13 +116,13 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
       string
     end
 
+    private
+
     def wrap_in_hcal(string, which)
       css_class = "dt#{which} dt-#{which}"
       formatted_time = time.strftime('%Y-%m-%dT%H:%M:%S')
       %(<time class="#{css_class}" title="#{formatted_time}" datetime="#{formatted_time}">#{string}</time>)
     end
-
-    private
 
     def get_parts
       parts = {

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -134,23 +134,17 @@ class TimeRange
     results
   end
 
-  def date_details(d)
-    # Get the parts for formatting a date, as a hash of 
-    # strings: keys (roughly) match the equivalent methods on Date, but only
-    # relevant keys will be filled in.
-    { :wday => Date::DAYNAMES[d.wday],
-      :month => Date::MONTHNAMES[d.month],
-      :day => d.day.to_s,
-      :year => d.year.to_s }
-  end
-
   def time_details(t)
     # Get the parts for formatting this time, as a hash of 
     # strings: keys (roughly) match the equivalent methods on DateTime, but only
     # relevant keys will be filled in.
     # - if it's exactly noon or midnight, :hour will be eg "noon"
     #   (with no other time fields)
-    details = date_details(t)
+    details = {
+      :wday => Date::DAYNAMES[t.wday],
+      :month => Date::MONTHNAMES[t.month],
+      :day => t.day.to_s,
+      :year => t.year.to_s }
     if t.min == 0
       return details.merge(:hour => "midnight") if t.hour == 0
       return details.merge(:hour => "noon") if t.hour == 12

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -52,16 +52,18 @@ class TimeRange
           # same day & am/pm
           # Tuesday, April 1, 2008 from 9-11am
           @start_format_list.delete(:suffix)
-          @end_format_list = [nil, :hour, :min, :suffix, nil]
-        else
-          # same day, different am/pm
-          # Tuesday, April 1, 2008 from 9am-1:30pm
-          @end_format_list = [nil, :hour, :min, :suffix, nil]
         end
+      end
+    end
+  end
+
+  def end_format_list
+    return @end_format_list if defined?(@end_format_list)
+    @end_format_list = if range?
+      if same_day?
+        [nil, :hour, :min, :suffix, nil]
       else
-        # different days: 
-        # Tuesday, April 1, 2008 at 9am through Wednesday, April 1, 2009 at 1:30pm
-        @end_format_list = @start_format_list.clone
+        [nil, :wday, :month, :day, :year, :at, :hour, :min, :suffix, nil]
       end
     end
   end
@@ -81,7 +83,7 @@ class TimeRange
   def remove_stuff_implied_by_context
     if context_date
       # Do it to both start & end lists
-      [[start_time, @start_format_list], [end_time, @end_format_list]].each do |t, list|
+      [[start_time, @start_format_list], [end_time, end_format_list]].each do |t, list|
         if t and list
           list.delete(:year) if context_date.year == t.year # same year
           [:wday, :month, :day, :at, :from].each do |k|
@@ -111,7 +113,7 @@ class TimeRange
 
   def end_text
     return unless range?
-    component(end_time, @end_details, @end_format_list, css_class: "dtend dt-end")
+    component(end_time, @end_details, end_format_list, css_class: "dtend dt-end")
   end
 
   def component(time, details, list, css_class: nil)

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -66,15 +66,6 @@ class TimeRange
     end
   end
 
-  def conjunction
-    return unless range?
-    if same_day?
-      text_format? ? "-" : "&ndash;"
-    else
-      " through "
-    end
-  end
-
   def range?
     end_time.present? && start_time != end_time
   end
@@ -102,13 +93,25 @@ class TimeRange
   end
 
   def combine_the_pieces
-    results = []
-    results += component(start_time, @start_details, @start_format_list, css_class: "dtstart dt-start")
-    if range?
-      results << conjunction
-      results += component(end_time, @end_details, @end_format_list, css_class: "dtend dt-end")
+    [start_text, conjunction, end_text].compact.join
+  end
+
+  def start_text
+    component(start_time, @start_details, @start_format_list, css_class: "dtstart dt-start")
+  end
+
+  def conjunction
+    return unless range?
+    if same_day?
+      text_format? ? "-" : "&ndash;"
+    else
+      " through "
     end
-    results.join
+  end
+
+  def end_text
+    return unless range?
+    component(end_time, @end_details, @end_format_list, css_class: "dtend dt-end")
   end
 
   def component(time, details, list, css_class: nil)

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -29,8 +29,8 @@ module TimeRangeHelper
     private
 
     def start_text
-      parts = TimeParts.new(start_time, context_date, from_prefix: same_day?, no_meridian: same_meridian?)
-      parts.to_s(format, "start")
+      part = TimePart.new(start_time, context_date, from_prefix: same_day?, no_meridian: same_meridian?)
+      part.to_s(format, "start")
     end
 
     def conjunction
@@ -44,8 +44,8 @@ module TimeRangeHelper
 
     def end_text
       return unless range?
-      parts = TimeParts.new(end_time, context_date, time_only: same_day?)
-      parts.to_s(format, "end")
+      part = TimePart.new(end_time, context_date, time_only: same_day?)
+      part.to_s(format, "end")
     end
 
     def range?
@@ -61,7 +61,7 @@ module TimeRangeHelper
     end
   end
 
-  class TimeParts
+  class TimePart
     def initialize(time, context, time_only: false, no_meridian: false, from_prefix: false)
       @time = time
       @context = context
@@ -75,7 +75,7 @@ module TimeRangeHelper
     attr_reader :time, :context, :parts
 
     def to_s(format, which)
-      TimePartsRenderer.new(self, format, which).to_s
+      TimePartRenderer.new(self, format, which).to_s
     end
 
     private
@@ -125,7 +125,7 @@ module TimeRangeHelper
     end
   end
 
-  class TimePartsRenderer < Struct.new(:parts, :format, :which)
+  class TimePartRenderer < Struct.new(:part, :format, :which)
     PREFIXES = {
       :hour => " ",
       [nil, :hour] => "",
@@ -150,7 +150,7 @@ module TimeRangeHelper
     private
 
     def text
-      parts.parts.reduce("") do |string, (key, value)|
+      part.parts.reduce("") do |string, (key, value)|
         prefix = (PREFIXES[[@last_key, key]] || PREFIXES[key])
         suffix = SUFFIXES[key]
         @last_key = key
@@ -160,7 +160,7 @@ module TimeRangeHelper
 
     def wrap_in_hcal(string, which)
       css_class = "dt#{which} dt-#{which}"
-      formatted_time = parts.time.strftime('%Y-%m-%dT%H:%M:%S')
+      formatted_time = part.time.strftime('%Y-%m-%dT%H:%M:%S')
       %(<time class="#{css_class}" title="#{formatted_time}" datetime="#{formatted_time}">#{string}</time>)
     end
   end

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -49,7 +49,7 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
   def text(time, parts, css_class: nil)
     results = []
     results << %Q|<time class="#{css_class}" title="#{time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
-    results << format_parts_by_list(parts)
+    results << parts.to_s
     results << %Q|</time>| if format == :hcal
     results.join
   end
@@ -74,39 +74,6 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
     same_day? && start_time.strftime("%p") == end_time.strftime("%p")
   end
 
-  PREFIXES = {
-    :hour => " ",
-    [nil, :hour] => "",
-    :year => ", ",
-    :end_hour => " ",
-    :end_year => ", ",
-    :at => " ",
-  }
-  SUFFIXES = {
-    :month => " ",
-    :wday => ", ",
-  }
-
-  def format_parts_by_list(parts)
-    # Given a hash of date parts, and a format_list of the keys
-    # that should be emitted, produce a list of the pieces.
-    #
-    # Include any extra pieces implied by juxtaposition: eg,
-    # if PREFIXES[:hour] is " ", include a " " piece just 
-    # before the hour, unless nil immediately 
-    # preceded :hour and we have a PREFIXES[[nil, :hour]], in
-    # which case we'll emit that instead.
-    results = []
-    last_key = nil
-    parts.each do |key, value|
-      results << (PREFIXES[[last_key, key]] || PREFIXES[key])
-      results << value
-      results << SUFFIXES[key]
-      last_key = key
-    end
-    results.join
-  end
-
   # Get the parts for formatting this time, as a hash of 
   # strings: keys (roughly) match the equivalent methods on DateTime, but only
   # relevant keys will be filled in.
@@ -126,7 +93,38 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
 
     attr_reader :time, :context
 
-    delegate :[], :[]=, :each, to: :@parts
+    PREFIXES = {
+      :hour => " ",
+      [nil, :hour] => "",
+      :year => ", ",
+      :end_hour => " ",
+      :end_year => ", ",
+      :at => " ",
+    }
+    SUFFIXES = {
+      :month => " ",
+      :wday => ", ",
+    }
+
+    def to_s
+      # Given a hash of date parts, and a format_list of the keys
+      # that should be emitted, produce a list of the pieces.
+      #
+      # Include any extra pieces implied by juxtaposition: eg,
+      # if PREFIXES[:hour] is " ", include a " " piece just
+      # before the hour, unless nil immediately
+      # preceded :hour and we have a PREFIXES[[nil, :hour]], in
+      # which case we'll emit that instead.
+      results = []
+      last_key = nil
+      @parts.each do |key, value|
+        results << (PREFIXES[[last_key, key]] || PREFIXES[key])
+        results << value
+        results << SUFFIXES[key]
+        last_key = key
+      end
+      results.join
+    end
 
     private
 

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -32,7 +32,7 @@ class TimeRange
   attr_reader :start_time, :end_time, :format, :context_date
 
   def to_s
-    combine_the_pieces
+    [start_text, conjunction, end_text].compact.join
   end
 
   private
@@ -84,10 +84,6 @@ class TimeRange
     [:wday, :month, :day, :at, :from].each do |key|
       details.delete(key)
     end if time.to_date == context_date
-  end
-
-  def combine_the_pieces
-    [start_text, conjunction, end_text].compact.join
   end
 
   def start_text

--- a/app/helpers/time_range_helper.rb
+++ b/app/helpers/time_range_helper.rb
@@ -29,7 +29,7 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
   private
 
   def start_text
-    text(start_time, start_parts, css_class: "dtstart dt-start")
+    start_parts.to_s(format, "start")
   end
 
   def conjunction
@@ -43,15 +43,7 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
 
   def end_text
     return unless range?
-    text(end_time, end_parts, css_class: "dtend dt-end")
-  end
-
-  def text(time, parts, css_class: nil)
-    results = []
-    results << %Q|<time class="#{css_class}" title="#{time.strftime('%Y-%m-%dT%H:%M:%S')}" datetime="#{time.strftime('%Y-%m-%dT%H:%M:%S')}">| if format == :hcal
-    results << parts.to_s
-    results << %Q|</time>| if format == :hcal
-    results.join
+    end_parts.to_s(format, "end")
   end
 
   def start_parts
@@ -106,7 +98,7 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
       :wday => ", ",
     }
 
-    def to_s
+    def to_s(format = :text, which = "start")
       # Given a hash of date parts, and a format_list of the keys
       # that should be emitted, produce a list of the pieces.
       #
@@ -123,7 +115,17 @@ class TimeRange < Struct.new(:start_time, :end_time, :format, :context_date)
         results << SUFFIXES[key]
         last_key = key
       end
-      results.join
+      string = results.join
+
+      string = wrap_in_hcal(string, which) if format == :hcal
+
+      string
+    end
+
+    def wrap_in_hcal(string, which)
+      css_class = "dt#{which} dt-#{which}"
+      formatted_time = time.strftime('%Y-%m-%dT%H:%M:%S')
+      %(<time class="#{css_class}" title="#{formatted_time}" datetime="#{formatted_time}">#{string}</time>)
     end
 
     private

--- a/app/models/event/ical_renderer.rb
+++ b/app/models/event/ical_renderer.rb
@@ -75,7 +75,7 @@ class Event < ActiveRecord::Base
 
     def description_range
       return unless multiday?
-      time_range = TimeRange.new(event.start_time, event.end_time, format: :text)
+      time_range = TimeRangeHelper.normalize_time(event, format: :text)
       "This event runs from #{time_range}.\n\nDescription:\n"
     end
 

--- a/spec/helpers/time_range_helper_spec.rb
+++ b/spec/helpers/time_range_helper_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
-describe "Time formatting", :type => :helper do
-  before(:each) do
-    @start_time = DateTime.new(2008, 4, 1, 9, 00)
-  end
+describe TimeRangeHelper do
+  let(:start_time) { DateTime.new(2008, 4, 1, 9, 00) }
 
   # Test all permutations of
   # - context-date: with vs without
@@ -32,8 +30,8 @@ describe "Time formatting", :type => :helper do
           expected = expected.gsub(%r|\<[^\>]*\>|,'') if format != :hcal
           expected = expected.gsub('&ndash;', '-') if format == :text
           it "should format #{label} in #{format} format as '#{expected}'" do
-            expect(TimeRange.new(@start_time, end_time, :format => format,
-              :context => context_date).to_s).to eq expected
+            actual = helper.normalize_time(start_time, end_time, format: format, context: context_date)
+            expect(actual).to eq expected
           end
         end
       end
@@ -43,13 +41,15 @@ describe "Time formatting", :type => :helper do
   describe "with objects" do
     it "should format from objects that respond to just start_time" do
       event = Event.new(:start_time => Time.parse('2008-04-01 13:30'))
-      expect(TimeRange.new(event, :format => :text).to_s).to eq "Tuesday, April 1, 2008 at 1:30pm"
+      actual = helper.normalize_time(event, format: :text)
+      expect(actual).to eq "Tuesday, April 1, 2008 at 1:30pm"
     end
 
     it "should format from objects that respond to both start_time and end_time" do
       event = Event.new(:start_time => Time.parse('2008-04-01 13:30'),
                         :end_time => Time.parse('2008-04-01 15:30'))
-      expect(TimeRange.new(event, :format => :text).to_s).to eq "Tuesday, April 1, 2008 from 1:30-3:30pm"
+      actual = helper.normalize_time(event, format: :text)
+      expect(actual).to eq "Tuesday, April 1, 2008 from 1:30-3:30pm"
     end
   end
 end


### PR DESCRIPTION
Mostly motivated by the 64 line `#to_s` method. Ended up splitting the class into three: `TimeRange`, `TimePart`, and `TimePartRenderer`.