### PR TITLE
Simplify event default date error handling

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -156,25 +156,12 @@ class EventsController < ApplicationController
   # is a value like :start, which refers to the `params[:date][+kind+]` value.
   # If there's an error, set an error message to flash.
   def date_or_default_for(kind)
-    if params[:date].present?
-      if params[:date].respond_to?(:has_key?)
-        if params[:date].has_key?(kind)
-          if params[:date][kind].present?
-            begin
-              return Date.parse(params[:date][kind])
-            rescue ArgumentError => e
-              append_flash :failure, "Can't filter by an invalid #{kind} date."
-            end
-          else
-            append_flash :failure, "Can't filter by an empty #{kind} date."
-          end
-        else
-          append_flash :failure, "Can't filter by a missing #{kind} date."
-        end
-      else
-        append_flash :failure, "Can't filter by a malformed #{kind} date."
-      end
-    end
-    return self.send("default_#{kind}_date")
+    default = send("default_#{kind}_date")
+    return default unless params[:date].present?
+
+    Date.parse(params[:date][kind])
+  rescue ArgumentError, TypeError
+    append_flash :failure, "Can't filter by an invalid #{kind} date."
+    default
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -221,19 +221,19 @@ describe EventsController, :type => :controller do
           it "should use the default if given a malformed parameter" do
             get :index, :date => "omgkittens"
             expect(assigns[date_field]).to eq send(date_field)
-            expect(response.body).to have_selector(".flash_failure", text: 'malformed')
+            expect(response.body).to have_selector(".flash_failure", text: 'invalid')
           end
 
           it "should use the default if given a missing parameter" do
             get :index, :date => {:foo => "bar"}
             expect(assigns[date_field]).to eq send(date_field)
-            expect(response.body).to have_selector(".flash_failure", text: 'missing')
+            expect(response.body).to have_selector(".flash_failure", text: 'invalid')
           end
 
           it "should use the default if given an empty parameter" do
             get :index, :date => {date_kind => ""}
             expect(assigns[date_field]).to eq send(date_field)
-            expect(response.body).to have_selector(".flash_failure", text: 'empty')
+            expect(response.body).to have_selector(".flash_failure", text: 'invalid')
           end
 
           it "should use the default if given an invalid parameter" do


### PR DESCRIPTION
Kill the pyramid of doom! Not strictly a refactoring, since it condenses four error messages into one, but I think "invalid" is a sufficient description for all four cases.