### PR TITLE
Refactor Source::Parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'ri_cal', '0.8.8'
 gem 'rubyzip'
 gem 'will_paginate', '3.0.5', require: ['will_paginate', 'will_paginate/array']
 gem 'httparty', '0.11.0'
+gem 'rest-client', '1.6.7'
 gem 'loofah', '1.2.1'
 gem 'loofah-activerecord', '1.1.0'
 gem 'bluecloth', '2.2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'paper_trail', '2.7.2'
 gem 'ri_cal', '0.8.8'
 gem 'rubyzip'
 gem 'will_paginate', '3.0.5', require: ['will_paginate', 'will_paginate/array']
-gem 'httparty', '0.11.0'
 gem 'rest-client', '1.6.7'
 gem 'loofah', '1.2.1'
 gem 'loofah-activerecord', '1.1.0'

--- a/app/models/source/parser.rb
+++ b/app/models/source/parser.rb
@@ -100,11 +100,12 @@ class Source::Parser < Struct.new(:opts)
     event_id = url[self.class.url_pattern, 1]
     return false unless event_id # Give up unless we find the identifier.
 
-    # Get URL and arguments for using the API.
-    api_args = block.call(event_id)
+    # Get URL and params for using the API.
+    url, params = *block.call(event_id)
 
     # Get data from the API.
-    data = HTTParty.get(*api_args)
+    data = RestClient.get(url, params: params, accept: "json").to_str
+    data = JSON.parse(data)
 
     # Stop if API tells us there's an error.
     raise Source::Parser::NotFound, error if error = data[error_key]

--- a/app/models/source/parser.rb
+++ b/app/models/source/parser.rb
@@ -14,19 +14,22 @@ class Source::Parser < Struct.new(:opts)
   # * :url - URL string to read as parser input.
   # * :content - String to read as parser input.
   def self.to_events(opts)
-    # start with the parser that matches the given URL
-    matched_parsers = parsers.sort_by do |parser|
-      match = parser.url_pattern.present? && opts[:url].try(:match, parser.url_pattern)
-      match ? 0 : 1
-    end
-
     # Return events from the first parser that suceeds
-    events = matched_parsers.lazy.collect { |parser|
+    events = matched_parsers(opts[:url]).lazy.collect { |parser|
       parser.new(opts).to_events
     }.detect(&:present?)
 
     events || []
   end
+
+  def self.matched_parsers(url)
+    # start with the parser that matches the given URL
+    parsers.sort_by do |parser|
+      match = parser.url_pattern.present? && url.try(:match, parser.url_pattern)
+      match ? 0 : 1
+    end
+  end
+  private_class_method :matched_parsers
 
   cattr_accessor(:parsers) { SortedSet.new }
 

--- a/app/models/source/parser.rb
+++ b/app/models/source/parser.rb
@@ -41,7 +41,7 @@ class Source::Parser < Struct.new(:opts)
 
   # Returns an Array of sorted string labels for the parsers.
   def self.labels
-    self.parsers.map(&:label).map(&:to_s).sort_by(&:downcase)
+    parsers.map { |p| p.label.to_s }.sort_by(&:downcase)
   end
 
   # Returns content read from a URL. Easier to stub.

--- a/app/models/source/parser/meetup.rb
+++ b/app/models/source/parser/meetup.rb
@@ -34,10 +34,8 @@ class Source::Parser::Meetup < Source::Parser
       [
         "https://api.meetup.com/2/event/#{event_id}",
         {
-          :query => {
-            :key => SECRETS.meetup_api_key,
-            :sign => 'true'
-          }
+          key: SECRETS.meetup_api_key,
+          sign: 'true'
         }
       ]
     end

--- a/app/models/source/parser/plancast.rb
+++ b/app/models/source/parser/plancast.rb
@@ -29,10 +29,8 @@ class Source::Parser::Plancast < Source::Parser
       [
         'http://api.plancast.com/02/plans/show.json',
         {
-          :query => {
-            :plan_id => event_id,
-            :extensions => 'place'
-          }
+          plan_id: event_id,
+          extensions: 'place'
         }
       ]
     end

--- a/spec/models/source/parser_spec.rb
+++ b/spec/models/source/parser_spec.rb
@@ -5,10 +5,6 @@ describe Source::Parser, "when reading content", :type => :model do
     stub_request(:get, "http://a.real/~url").to_return(body: "42")
     expect(Source::Parser.read_url("http://a.real/~url")).to eq "42"
   end
-
-  it "should read from a wacky URL" do
-    expect { Source::Parser.read_url("not://a.real/~url") }.to raise_error(Errno::ENOENT)
-  end
 end
 
 describe Source::Parser, "when subclassing", :type => :model do


### PR DESCRIPTION
Tied up some loose ends in `Source::Parser`, most notably replacing the hand-rolled http GET code with the `rest-client` gem. `httparty` was already included in the project, but couldn't handle basic auth directly in the url, while `rest-client` is able to.

After that, it seemed silly to have two http clients in the project, so I went ahead and replaced the one usage of `httparty` with `rest-client`.