### PR TITLE
Flatten config variables in yml files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ Changes
 List of Calagator stable releases and changes, with the latest at the top:
 
   * [master]
+  * [!] Adopted a flat configuration format for easier Heroku deployment. See config/secrets.yml.sample.
   * v0.20150320
     * [!] Dropped support for Ruby 1.8.7, and 1.9.3. Use Ruby 2.0+.
     * Switched from outdated v2 Google Maps to a more flexible leaflet-based mapping system.
@@ -92,7 +93,7 @@ List of Calagator stable releases and changes, with the latest at the top:
   * v0.20120709
     * [!] This release drops support for 'acts_as_solr' search backend.  Please migrate to the 'sunspot' backend instead.
     * [DEPENDENCY] Upgraded most external dependencies.
-    * [MIGRATION] Remove obsolete tables and columns that may have been left behind. 
+    * [MIGRATION] Remove obsolete tables and columns that may have been left behind.
     * Improved compatibility with Ruby 1.9.x.
     * Improved tag cloud implementation and styling.
     * Improved ATOM output.

--- a/app/helpers/calagator/mapping_helper.rb
+++ b/app/helpers/calagator/mapping_helper.rb
@@ -2,11 +2,11 @@ module Calagator
 
 module MappingHelper
   def map_provider
-    (SECRETS.mapping && SECRETS.mapping["provider"]) || 'stamen'
+    SECRETS.mapping_provider || 'stamen'
   end
 
   def map_tiles
-    (SECRETS.mapping && SECRETS.mapping["tiles"]) || 'terrain'
+    SECRETS.mapping_tiles || 'terrain'
   end
 
   def leaflet_js
@@ -19,7 +19,7 @@ module MappingHelper
       "mapbox" => ["https://api.tiles.mapbox.com/mapbox.js/v1.3.1/mapbox.standalone.js"],
       "esri"   => ["http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/0.0.1-beta.5/esri-leaflet.js"],
       "google" => [
-        "https://maps.googleapis.com/maps/api/js?key=#{SECRETS.mapping && SECRETS.mapping["google_maps_api_key"]}&sensor=false",
+        "https://maps.googleapis.com/maps/api/js?key=#{SECRETS.mapping_google_maps_api_key}&sensor=false",
         "leaflet_google_layer",
       ],
     }[map_provider]
@@ -58,7 +58,7 @@ module MappingHelper
 
         var venueIcon = L.AwesomeMarkers.icon({
           icon: 'star',
-          color: '#{SECRETS.mapping['marker_color']}'
+          color: '#{SECRETS.mapping_marker_color}'
         })
 
         var markers = [#{markers.join(", ")}];

--- a/config/initializers/geokit.rb
+++ b/config/initializers/geokit.rb
@@ -12,11 +12,11 @@ GeoKit::default_formula = :sphere
 
 # This is the timeout value in seconds to be used for calls to the geocoder web
 # services.  For no timeout at all, comment out the setting.  The timeout unit
-# is in seconds. 
+# is in seconds.
 GeoKit::Geocoders::request_timeout = 3
 
 # These settings are used if web service calls must be routed through a proxy.
-# These setting can be nil if not needed, otherwise, addr and port must be 
+# These setting can be nil if not needed, otherwise, addr and port must be
 # filled in at a minimum.  If the proxy requires authentication, the username
 # and password can be provided as well.
 GeoKit::Geocoders::proxy_addr = nil
@@ -28,15 +28,15 @@ GeoKit::Geocoders::proxy_pass = nil
 # See http://developer.yahoo.com/faq/index.html#appid
 # and http://developer.yahoo.com/maps/rest/V1/geocode.html
 GeoKit::Geocoders::yahoo = 'REPLACE_WITH_YOUR_YAHOO_KEY'
-    
-# This is your Google Maps geocoder key. 
+
+# This is your Google Maps geocoder key.
 # See http://www.google.com/apis/maps/signup.html
 # and http://www.google.com/apis/maps/documentation/#Geocoding_Examples
 #
 # CALAGATOR: was GeoKit::Geocoders::google = 'REPLACE_WITH_YOUR_GOOGLE_KEY',
 # but since each developer needs their own, we get it from the secrets file.
 #
-google_key = SECRETS.mapping && SECRETS.mapping["google_maps_api_key"]
+google_key = SECRETS.mapping_google_maps_api_key
 old_keys_path = Rails.root.join('config','geocoder_api_keys.yml')
 
 if google_key
@@ -48,14 +48,14 @@ else
 end
 
 # This is your username and password for geocoder.us.
-# To use the free service, the value can be set to nil or false.  For 
+# To use the free service, the value can be set to nil or false.  For
 # usage tied to an account, the value should be set to username:password.
 # See http://geocoder.us
 # and http://geocoder.us/user/signup
-GeoKit::Geocoders::geocoder_us = false 
+GeoKit::Geocoders::geocoder_us = false
 
 # This is your authorization key for geocoder.ca.
-# To use the free service, the value can be set to nil or false.  For 
+# To use the free service, the value can be set to nil or false.  For
 # usage tied to an account, set the value to the key obtained from
 # Geocoder.ca.
 # See http://geocoder.ca
@@ -65,7 +65,7 @@ GeoKit::Geocoders::geocoder_ca = false
 # This is the order in which the geocoders are called in a failover scenario
 # If you only want to use a single geocoder, put a single symbol in the array.
 # Valid symbols are :google, :yahoo, :us, and :ca.
-# Be aware that there are Terms of Use restrictions on how you can use the 
+# Be aware that there are Terms of Use restrictions on how you can use the
 # various geocoders.  Make sure you read up on relevant Terms of Use for each
 # geocoder you are going to use.
 #

--- a/config/initializers/geokit.rb
+++ b/config/initializers/geokit.rb
@@ -43,6 +43,8 @@ if google_key
   GeoKit::Geocoders::google = google_key
 elsif File.exist? old_keys_path
   raise "Loading keys from config/geocoder_api_keys.yml is deprecated. Please use config/secrets.yml instead."
+elsif SECRETS.mapping.present?
+  raise "SECRETS.mapping is no longer used. Please refer to config/secrets.yml.sample."
 else
   puts "Warning: No Google Maps API key was set. Geocoding will not function."
 end

--- a/lib/generators/calagator/templates/config/secrets.yml.sample
+++ b/lib/generators/calagator/templates/config/secrets.yml.sample
@@ -37,47 +37,46 @@ session_name: 'calagator'
 
 # Configure a mapping provider
 # Stamen's terrain tiles will be used by default.
-mapping:
-  # Map marker color
-  # Values: red, darkred, orange, green, darkgreen, blue, purple, darkpuple, cadetblue
-  marker_color: green
+# Map marker color
+# Values: red, darkred, orange, green, darkgreen, blue, purple, darkpuple, cadetblue
+mapping_marker_color: green
 
-  # A Google Maps API key is required to use Google's geocoding service
-  # as well as to display maps using their API.
-  #
-  # Get one at: https://developers.google.com/maps/documentation/javascript/tutorial#api_key
-  google_maps_api_key: <your google maps v3 API key>
+# A Google Maps API key is required to use Google's geocoding service
+# as well as to display maps using their API.
+#
+# Get one at: https://developers.google.com/maps/documentation/javascript/tutorial#api_key
+mapping_google_maps_api_key: <your google maps v3 API key>
 
-  # The tile provider to use when rendering maps with Leaflet.
-  # One of: leaflet, stamen, mapbox, google
-  # provider: stamen
-  #
-  # The tiles to use for the map, see the docs for individual Leaflet plugins.
-  # For stamen, this can be one of: terrain, toner, watercolor
-  # tiles: terrain
-  #
-  #== Examples ==
-  # Stamen
-  # (available tiles: terrain, toner, watercolor)
-  # provider: stamen
-  # tiles: watercolor
-  #
-  # MapBox Streets (use a map from your own account)
-  # provider: mapbox
-  # tiles: examples.map-9ijuk24y
-  #
-  # Google Maps
-  # provider: google
-  # tiles: ROADMAP
-  # google_maps_api_key: <your google maps v3 API key>
-  #
-  # OpenStreetMap
-  # provider: leaflet
-  # tiles: http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
-  # 
-  # Esri
-  # (available tiles: Gray, Streets, Oceans, Topographic)
-  # provider: esri
-  # tiles: Gray
+# The tile provider to use when rendering maps with Leaflet.
+# One of: leaflet, stamen, mapbox, google
+# mapping_provider: stamen
+#
+# The tiles to use for the map, see the docs for individual Leaflet plugins.
+# For stamen, this can be one of: terrain, toner, watercolor
+# mapping_tiles: terrain
+#
+#== Examples ==
+# Stamen
+# (available tiles: terrain, toner, watercolor)
+# mapping_provider: stamen
+# mapping_tiles: watercolor
+#
+# MapBox Streets (use a map from your own account)
+# mapping_provider: mapbox
+# mapping_tiles: examples.map-9ijuk24y
+#
+# Google Maps
+# mapping_provider: google
+# mapping_tiles: ROADMAP
+# mapping_google_maps_api_key: <your google maps v3 API key>
+#
+# OpenStreetMap
+# mapping_provider: leaflet
+# mapping_tiles: http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
+#
+# Esri
+# (available tiles: Gray, Streets, Oceans, Topographic)
+# mapping_provider: esri
+# mapping_tiles: Gray
 
 #===[ fin ]=============================================================


### PR DESCRIPTION
Flattening the variables in the yml files constitutes a breaking change. But I wanted to ask - should the variables stored in `themes/*/settings.yml` be moved to `config/secrets.yml`? 

See the previous discussions for pull request #274 and the original issue #158 