### PR TITLE
Moves factory_girl and faker into developemnt/test to fix seed bug.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -63,5 +63,6 @@ These people have contributed to Calagator's design and implementation:
   * Ward Cunningham
   * [yves_guillou](http://openclipart.org/user-detail/yves_guillou)
   * Garrison Jensen
+  * Zach Abrahams
 
 Facilities for many code sprints were generously donated by [Cubespace](http://cubespacepdx.com/), "an innovative workspace community in Portland, Oregon. We provide work stations, meeting rooms, and big office amenities to people who would otherwise be working from their homes, coffee shops, or wherever they can set up their laptops or use their cell phones"

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,8 @@ group :development, :test do
   gem 'rspec-collection_matchers'
   gem 'spring', '1.1.3'
   gem 'spring-commands-rspec', '1.0.2'
+  gem 'factory_girl_rails'
+  gem 'faker', '1.4.3'
 
   # Do not install these interactive libraries onto the continuous integration server.
   unless ENV['CI'] || ENV['TRAVIS']
@@ -109,11 +111,9 @@ group :test do
   gem 'capybara', '2.4.3'
   gem 'coveralls', '0.7.0', require: false
   gem 'database_cleaner'
-  gem 'factory_girl_rails'
   gem 'poltergeist', '1.5.1'
   gem 'timecop', '~> 0.7'
   gem 'webmock', '~> 1.20'
-  gem 'faker', '1.4.3'
 end
 
 # Gems used only for assets and not required


### PR DESCRIPTION
I noticed that rake db:seed needs factory girl and faker, but they currently aren't available in development.  I updated the Gemfile to put them in the :development, :test group !