### PR TITLE
add ruby version to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@
 #=======================================================================
 
 source 'https://rubygems.org'
-
+ruby '2.1.5'
 # Database driver
 require "./lib/database_yml_reader"
 adapter = DatabaseYmlReader.read.adapter


### PR DESCRIPTION
This is so new contributors get a clear error when they run bundle instead of getting a messy stack trace later on. I set it to the last stable version pre 2.2.0. But it would also raise an error if they were using an older version. 

Error users would see:
```
Your Ruby version is 2.2.0, but your Gemfile specified 2.1.5

