### PR TITLE
Engine: Replace theme settings.yml with a calagator initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,8 @@ vagrant/cookbooks/vagrant/recipes/local.rb
 .bundle/
 pkg/
 spec/dummy/db/*.sqlite3
-spec/dummy/log/*.log
+spec/dummy/log/*
+spec/dummy/solr/*
 spec/dummy/tmp/
 spec/dummy/.sass-cache
 .sass-cache

--- a/Guardfile
+++ b/Guardfile
@@ -1,5 +1,5 @@
 # Run specs
-guard 'rspec' do
+guard 'rspec', cmd: "bundle exec rspec" do
   watch(%r{^app/(.+)\.rb$}) { |m| "spec/#{m[1]}_spec.rb" }
   watch(%r{^spec/.+_spec\.rb|^leech_media.rb$})
 end

--- a/app/helpers/calagator/application_helper.rb
+++ b/app/helpers/calagator/application_helper.rb
@@ -53,7 +53,7 @@ module ApplicationHelper
   def datestamp(item)
     stamp = "This item was "
     if item.source.nil?
-      stamp << "added directly to #{SETTINGS.name}"
+      stamp << "added directly to #{Calagator.title}"
     else
       stamp << "imported from " << link_to(truncate(item.source.name, :length => 40), helper.url_for(item.source))
     end

--- a/app/models/calagator/event/ical_renderer.rb
+++ b/app/models/calagator/event/ical_renderer.rb
@@ -33,7 +33,7 @@ class Event < ActiveRecord::Base
     end
 
     def self.add_name(output)
-      output.sub(/(CALSCALE:\w+)/i, "\\1\nX-WR-CALNAME:#{SETTINGS.name}\nMETHOD:PUBLISH")
+      output.sub(/(CALSCALE:\w+)/i, "\\1\nX-WR-CALNAME:#{Calagator.title}\nMETHOD:PUBLISH")
     end
 
     def self.normalize_line_endings(output)

--- a/app/views/calagator/events/index.atom.builder
+++ b/app/views/calagator/events/index.atom.builder
@@ -5,7 +5,7 @@ cache_if(@perform_caching, Calagator::CacheObserver.daily_key_for("events_atom",
     else
       "Events"
     end
-    feed.title("#{SETTINGS.name}: #{page_title}")
+    feed.title("#{Calagator.title}: #{page_title}")
 
     unless @events.size == 0
       feed.updated(@events.present? ? @events.sort_by(&:updated_at).last.updated_at : Time.now)

--- a/app/views/calagator/events/show.html.erb
+++ b/app/views/calagator/events/show.html.erb
@@ -9,7 +9,7 @@
 <% content_for :open_graph_tags do %>
   <meta property="og:title" content="<%= @event.title %>" />
   <meta property="og:description" content="<%= @event.description %>" />
-  <meta property="og:site_name" content="<%= Calendar.name %>" />
+  <meta property="og:site_name" content="<%= Calagator.name %>" />
   <meta property="og:url" content="<%= event_url(@event) %>">
 <% end %>
 

--- a/app/views/calagator/events/show.html.erb
+++ b/app/views/calagator/events/show.html.erb
@@ -9,7 +9,7 @@
 <% content_for :open_graph_tags do %>
   <meta property="og:title" content="<%= @event.title %>" />
   <meta property="og:description" content="<%= @event.description %>" />
-  <meta property="og:site_name" content="<%= SETTINGS.name %>" />
+  <meta property="og:site_name" content="<%= Calendar.name %>" />
   <meta property="og:url" content="<%= event_url(@event) %>">
 <% end %>
 

--- a/app/views/calagator/site/opensearch.xml.builder
+++ b/app/views/calagator/site/opensearch.xml.builder
@@ -1,7 +1,7 @@
 xml.instruct!
 xml.OpenSearchDescription('xmlns' => 'http://a9.com/-/spec/opensearch/1.1/', 'xmlns:moz' => 'http://www.mozilla.org/2006/browser/search/') do
-  xml.ShortName SETTINGS.name
-  xml.Description "Search #{SETTINGS.name}"
+  xml.ShortName Calagator.title
+  xml.Description "Search #{Calagator.title}"
   xml.InputEncoding "UTF-8"
   # The sub call at the end of this line is because we want to use the rails URL helper, but don't want to urlencode the curly braces.
   xml.Url('type' => 'text/html', 'method' => 'get', 'template' => search_events_url(:query => "searchTerms").sub('searchTerms', '{searchTerms}') )

--- a/app/views/calagator/sources/new.html.erb
+++ b/app/views/calagator/sources/new.html.erb
@@ -25,7 +25,7 @@
     <li class='input'>
       <p class='inline-hints'>
       <b>Bookmarklet</b>: Import pages faster by adding the following bookmark to your browser's bookmarks and click it when you're visiting a webpage that contains events that you'd like to import:
-      <%= link_to "Add to #{SETTINGS.name}", "javascript:d=document;q=(d.location.href);w=window;location.href='#{new_source_url}?url='+escape(q);" %>
+      <%= link_to "Add to #{Calagator.title}", "javascript:d=document;q=(d.location.href);w=window;location.href='#{new_source_url}?url='+escape(q);" %>
       </p>
     </li>
   <% end %>

--- a/app/views/calagator/venues/map.html.erb
+++ b/app/views/calagator/venues/map.html.erb
@@ -1,4 +1,4 @@
 <h1>Big Map of Venues</h1>
 <div id='venues_map'>
-  <%= map @venues, SETTINGS.venues_map_options || SETTINGS.venues_google_map_options %>
+  <%= map @venues, zoom: Calagator.venues_map_zoom, center: Calagator.venues_map_center %>
 </div>

--- a/app/views/calagator/venues/map.html.erb
+++ b/app/views/calagator/venues/map.html.erb
@@ -1,4 +1,4 @@
 <h1>Big Map of Venues</h1>
 <div id='venues_map'>
-  <%= map @venues, zoom: Calagator.venues_map_zoom, center: Calagator.venues_map_center %>
+  <%= map @venues, Calagator.venues_map_options %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,12 +7,12 @@
     <%= yield :open_graph_tags %>
     <title>
       <%= "#{yield(:title)} » " if content_for?(:title) -%>
-      <%= SETTINGS.name -%>: <%= SETTINGS.tagline -%>
+      <%= Calagator.title -%>: <%= Calagator.tagline -%>
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-    <link rel='search' type='application/opensearchdescription+xml' href='<%= "#{root_path}opensearch.xml" %>'  title='<%= SETTINGS.name %>' />
+    <link rel='search' type='application/opensearchdescription+xml' href='<%= "#{root_path}opensearch.xml" %>'  title='<%= Calagator.title %>' />
 
     <!-- Stylesheets, static -->
     <%= stylesheet_link_tag 'application', 'theme', :media => :all %>
@@ -45,7 +45,7 @@
 
   <div id="outer">
     <div id="global_header">
-      <%= link_to SETTINGS.name, root_path, id: "project_title" %>
+      <%= link_to Calagator.title, root_path, id: "project_title" %>
 
       <div id="top_menu">
          <div id='app_menu'>
@@ -85,7 +85,7 @@
     </div>
 
     <div id="top_footer">
-      <%= URI.parse(SETTINGS.url).host %>
+      <%= URI.parse(Calagator.url).host %>
       <%= source_code_version %>
       &nbsp;
       &nbsp;

--- a/lib/calagator/engine.rb
+++ b/lib/calagator/engine.rb
@@ -11,11 +11,12 @@ module Calagator
 
   # settings with defaults
   class << self
-    mattr_accessor :title, :tagline, :url, :timezone, :precompile_assets, :venues_map_zoom, :venues_map_center
+    mattr_accessor :title, :tagline, :url, :timezone, :precompile_assets, :venues_map_options
     self.title = 'Calagator'
     self.tagline = 'A Tech Calendar'
     self.url = 'http://calagator.org/'
     self.timezone = 'Pacific Time (US & Canada)'
+    self.venues_map_options = {}
   end
 
   # map the attrs from initializer

--- a/lib/calagator/engine.rb
+++ b/lib/calagator/engine.rb
@@ -1,5 +1,25 @@
 module Calagator
   class Engine < ::Rails::Engine
     isolate_namespace Calagator
+
+    config.before_initialize do
+      # Read secrets
+      require 'secrets_reader'
+      ::SECRETS = SecretsReader.read
+    end
+  end
+
+  # settings with defaults
+  class << self
+    mattr_accessor :title, :tagline, :url, :timezone, :precompile_assets, :venues_map_zoom, :venues_map_center
+    self.title = 'Calagator'
+    self.tagline = 'A Tech Calendar'
+    self.url = 'http://calagator.org/'
+    self.timezone = 'Pacific Time (US & Canada)'
+  end
+
+  # map the attrs from initializer
+  def self.setup(&block)
+    yield self
   end
 end

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -41,25 +41,6 @@ module Dummy
       "errors.css"
     ]
 
-    #---[ Secrets and settings ]--------------------------------------------
-
-    config.before_initialize do
-      # Read secrets
-      require 'secrets_reader'
-      ::SECRETS = SecretsReader.read
-
-      # Read theme
-      require 'theme_reader'
-      ::THEME_NAME = ThemeReader.read
-
-      # Read theme settings
-      require 'settings_reader'
-      ::SETTINGS = SettingsReader.read(Rails.root.join('themes',THEME_NAME,'settings.yml'))
-
-      # Set timezone for Rails
-      config.time_zone = SETTINGS.timezone || 'Pacific Time (US & Canada)'
-    end
-
     # Set timezone for OS
     config.after_initialize do
       ENV['TZ'] = Time.zone.tzinfo.identifier

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -62,7 +62,7 @@ module Dummy
 
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = Calagator.timezone
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]

--- a/spec/dummy/config/initializers/calagator.rb
+++ b/spec/dummy/config/initializers/calagator.rb
@@ -1,0 +1,27 @@
+Calagator.setup do |config|
+
+  # Site's name
+  name = 'Calagator'
+
+  # Site's tagline
+  tagline = "Portland's Tech Calendar"
+
+  # Site's URL with trailing slash
+  url = 'http://calagator.org/'
+
+  # Default timezone, run "rake -D time" for information on how to display known timezones
+  timezone = 'Pacific Time (US & Canada)'
+
+  # Precompile additional theme assets (theme.js, theme.css, and images already included)
+  precompile_assets = %w( mobile.css print.css )
+
+  # Map to display on /venues page:
+  venues_map_options = {
+    # Zoom magnification level:
+    zoom: 12,
+    # Center of the map, in latitude and longitude.
+    # If no center is specified, the map will zoom to fit all markers.
+    center: [45.518493, -122.660737]
+  }
+
+end

--- a/spec/dummy/config/initializers/calagator.rb
+++ b/spec/dummy/config/initializers/calagator.rb
@@ -1,22 +1,22 @@
 Calagator.setup do |config|
 
   # Site's name
-  name = 'Calagator'
+  config.title = 'Calagator'
 
   # Site's tagline
-  tagline = "Portland's Tech Calendar"
+  config.tagline = "Portland's Tech Calendar"
 
   # Site's URL with trailing slash
-  url = 'http://calagator.org/'
+  config.url = 'http://calagator.org/'
 
   # Default timezone, run "rake -D time" for information on how to display known timezones
-  timezone = 'Pacific Time (US & Canada)'
+  config.timezone = 'Pacific Time (US & Canada)'
 
   # Precompile additional theme assets (theme.js, theme.css, and images already included)
-  precompile_assets = %w( mobile.css print.css )
+  config.precompile_assets = %w( mobile.css print.css )
 
   # Map to display on /venues page:
-  venues_map_options = {
+  config.venues_map_options = {
     # Zoom magnification level:
     zoom: 12,
     # Center of the map, in latitude and longitude.

--- a/spec/dummy/themes/default/views/layouts/application.html.erb
+++ b/spec/dummy/themes/default/views/layouts/application.html.erb
@@ -7,12 +7,12 @@
     <%= yield :open_graph_tags %>
     <title>
       <%= "#{yield(:title)} » " if content_for?(:title) -%>
-      <%= SETTINGS.name -%>: <%= SETTINGS.tagline -%>
+      <%= Calagator.title -%>: <%= Calagator.tagline -%>
     </title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
-    <link rel='search' type='application/opensearchdescription+xml' href='<%= "#{root_path}opensearch.xml" %>'  title='<%= SETTINGS.name %>' />
+    <link rel='search' type='application/opensearchdescription+xml' href='<%= "#{root_path}opensearch.xml" %>'  title='<%= Calagator.title %>' />
 
     <!-- Stylesheets, static -->
     <%= stylesheet_link_tag 'application', 'theme', :media => :all %>
@@ -45,7 +45,7 @@
 
   <div id="outer">
     <div id="global_header">
-      <%= link_to SETTINGS.name, root_path, id: "project_title" %>
+      <%= link_to Calagator.title, root_path, id: "project_title" %>
 
       <div id="top_menu">
          <div id='app_menu'>
@@ -85,7 +85,7 @@
     </div>
 
     <div id="top_footer">
-      <%= URI.parse(SETTINGS.url).host %>
+      <%= URI.parse(Calagator.url).host %>
       <%= source_code_version %>
       &nbsp;
       &nbsp;

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -807,7 +807,7 @@ describe Event, :type => :model do
       end
 
       it "should include the calendar name" do
-        expect(@data).to match /\sX-WR-CALNAME:#{SETTINGS.name}\s/
+        expect(@data).to match /\sX-WR-CALNAME:#{Calagator.title}\s/
       end
 
       it "should include the method" do


### PR DESCRIPTION
Here's an option to replace the settings.yml file to make it engine-friendly. Gem specific settings can be set in `config/initializers/calagator.rb`. If we go this route I can update #311 to setup this file on `rails g calagator:install`, as well as add it to the calagator.org repo. 

New settings can be defined in `lib/calagator/engine.rb`, where a default can also be applied.

cc @botandrose 