### PR TITLE
Create Default url setting option in secrets.yml File

### DIFF
--- a/config/initializers/set_default_url_host.rb
+++ b/config/initializers/set_default_url_host.rb
@@ -1,0 +1,1 @@
+Calagator::Application.config.action_controller.default_url_options = {host: SECRETS.default_url_host} if SECRETS.default_url_host

--- a/config/secrets.yml.sample
+++ b/config/secrets.yml.sample
@@ -16,6 +16,10 @@ administrator_email: 'your@email.addr'
 admin_username: 'admin'
 admin_password: 'kitties!'
 
+# Setting default url host config options for external site redirects.
+# If provided, will aid in generating full URLs.
+default_url_host: 'calagator.org'
+
 # Secret code for verifying cookie session data integrity. If you change it,
 # all old sessions will become invalid! Make sure the secret is at least 30
 # characters and all random, no regular words or you'll be exposed to
@@ -74,7 +78,7 @@ mapping:
   # OpenStreetMap
   # provider: leaflet
   # tiles: http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
-  # 
+  #
   # Esri
   # (available tiles: Gray, Streets, Oceans, Topographic)
   # provider: esri


### PR DESCRIPTION
Add `default_url_options` initializer so that Rails can appropriately generate full URLs for outside sites and feeds. Solution to issue #304.