### PR TITLE
Restrict ruby version in gemspec

### DIFF
--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
   s.description = "Calagator is an open source community calendaring platform"
   s.license     = "MIT"
 
+  s.required_ruby_version = ['>= 2.0.0', '< 2.2.0']
+
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE.txt", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 


### PR DESCRIPTION
We currently support ruby versions between 2.0 and 2.1.5. Per discussion on #300, we can restrict this via the gemspec now that we've merged the `engine` branch.