### PR TITLE
Fixed occasional test failure resulting from page status response code o...

### DIFF
--- a/spec/features/admin_auth_spec.rb
+++ b/spec/features/admin_auth_spec.rb
@@ -15,7 +15,7 @@ feature 'Administrative suite is hidden behind an http basic auth wall' do
     scenario "Authenticated users are permitted in #{path}" do
       page.driver.basic_authorize SECRETS.admin_username, SECRETS.admin_password
       visit path
-      expect(page.status_code).to eq 200
+	  expect([200, 304]).to include page.status_code
     end
   end
 end


### PR DESCRIPTION
Fixed occasional test failure resulting from page status response code only testing for 200 instead of 304 (occurs on seed 44757). 

On command `bundle exec rspec --seed 44757` it fails: expects 200, got 304. The change just tests whether the page.status_code is equal to 200 or 304 (whether or not page.status_code is included in the array [200, 304]).