### PR TITLE
upgrade to ruby 2.2 now that calagator is compatible

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -60,10 +60,11 @@ gem install bundler rake
 # Bundle install
 su ${VAGRANT_USER} -l -c 'bundle check || bundle --local || bundle'
 
-# Setup database
-# TODO: what should the out of box experience be here?
-# Should we pregenerate the dummy app?
-su ${VAGRANT_USER} -l -c 'bundle exec rake db:create:all db:migrate'
+# Create dummy app
+if [ ! -e "${APPDIR}/spec/dummy/" ] ; then
+  su ${VAGRANT_USER} -l -c 'bin/calagator new spec/dummy --dummy'
+  su ${VAGRANT_USER} -l -c 'rake app:db:migrate app:db:setup'
+fi
 
 # Cleanup for box image build
 # apt-get clean

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -27,8 +27,11 @@ apt-get install -y ruby${RUBY_VERSION} ruby${RUBY_VERSION}-dev build-essential p
 # Useful tools
 apt-get install -y git-core screen tmux elinks 
 
-# Postgresql
+# Postgresql. Do we really want a full postgres running?
 apt-get install -y postgresql-$PGSQL_VERSION libpq-dev postgresql-client-common postgresql-contrib-$PGSQL_VERSION postgresql-$PGSQL_VERSION-postgis-$PGIS_VERSION
+
+# Req to build mysql2 gem
+apt-get install libmysqlclient-dev
 
 # Install Java for Solr
 apt-get install -y openjdk-7-jre-headless

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -6,13 +6,17 @@ PGSQL_VERSION=9.3
 RUBY_VERSION=2.1
 
 # Fix locale so that Postgres creates databases in UTF-8
-locale-gen en_US.UTF-8
-dpkg-reconfigure locales
+if [ "${LANG}" != "en_US.UTF-8" ] ; then
+  locale-gen en_US.UTF-8
+  dpkg-reconfigure locales
+fi
 
 # Add source for up-to-date ruby
 # docs: https://www.brightbox.com/docs/ruby/ubuntu/
-add-apt-repository -y ppa:brightbox/ruby-ng
-apt-get update -y
+if [ ! -e "/etc/apt/sources.list.d/brightbox-ruby-ng-trusty.list" ] ; then
+  add-apt-repository -y ppa:brightbox/ruby-ng
+  apt-get update -y
+fi
 
 # remove preinstalled ruby
 apt-get remove ruby1.9.1 libruby1.9.1

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -61,7 +61,9 @@ gem install bundler rake
 su ${VAGRANT_USER} -l -c 'bundle check || bundle --local || bundle'
 
 # Setup database
-su ${VAGRANT_USER} -l -c 'bundle exec rake db:create:all db:migrate db:test:prepare'
+# TODO: what should the out of box experience be here?
+# Should we pregenerate the dummy app?
+su ${VAGRANT_USER} -l -c 'bundle exec rake db:create:all db:migrate'
 
 # Cleanup for box image build
 # apt-get clean

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -3,7 +3,7 @@
 APPDIR="/vagrant"
 VAGRANT_USER="vagrant"
 PGSQL_VERSION=9.3
-RUBY_VERSION=2.1
+RUBY_VERSION=2.2
 
 # Fix locale so that Postgres creates databases in UTF-8
 if [ "${LANG}" != "en_US.UTF-8" ] ; then
@@ -19,7 +19,7 @@ if [ ! -e "/etc/apt/sources.list.d/brightbox-ruby-ng-trusty.list" ] ; then
 fi
 
 # remove preinstalled ruby
-apt-get remove ruby1.9.1 libruby1.9.1
+apt-get remove ruby1.9.1 libruby1.9.1 libruby2.1
 
 # Required packages
 apt-get install -y ruby${RUBY_VERSION} ruby${RUBY_VERSION}-dev build-essential phantomjs libcurl4-openssl-dev libsqlite3-dev libxml2 libxml2-dev libxslt1.1 libxslt1-dev


### PR DESCRIPTION
also generates `spec/dummy` and sets up db so people can run the app right away