### PR TITLE
Fix NoMethodError when leaflet chosen as mapping provider

### DIFF
--- a/app/helpers/calagator/mapping_helper.rb
+++ b/app/helpers/calagator/mapping_helper.rb
@@ -20,9 +20,9 @@ module MappingHelper
       "esri"   => ["http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/0.0.1-beta.5/esri-leaflet.js"],
       "google" => [
         "https://maps.googleapis.com/maps/api/js?key=#{SECRETS.mapping_google_maps_api_key}&sensor=false",
-        "leaflet_google_layer",
-      ],
-    }[map_provider]
+        "leaflet_google_layer"
+      ]
+    }[map_provider] || []
   end
 
   def mapping_js_includes


### PR DESCRIPTION
When leaflet was chosen as a mapping provider, `map_provider_dependencies` was returning `nil`, since there was no leaflet key in the hash. 

* Fixes incorrect `nil` value
* Use `.fetch` to give better errors in the future