### PR TITLE
Only run latest rails tests with rbx to cut down on Travis time.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,32 @@
 sudo: false
 language: ruby
+
 rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.0
   - rbx-2
-env:
-  matrix:
-    - DB=mysql
-    - DB=postgresql
-    - DB=sqlite3
-matrix:
-  fast_finish: true
-  allow_failures:
-    - rvm: rbx-2
 
 gemfile:
   - gemfiles/rails_4_0.gemfile
   - gemfiles/rails_4_1.gemfile
   - gemfiles/rails_4_2.gemfile
+
+env:
+  matrix:
+    - DB=mysql
+    - DB=postgresql
+    - DB=sqlite3
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: rbx-2
+  exclude:
+    - rvm: rbx-2
+      gemfile: gemfiles/rails_4_0.gemfile
+    - rvm: rbx-2
+      gemfile: gemfiles/rails_4_1.gemfile
 
 before_script:
   - bundle exec bin/calagator new spec/dummy --dummy --database=$DB --postgres-username=postgres


### PR DESCRIPTION
Trying to cut down overall Travis runtime, now that we have 4(Rubies) * 3(Rails) * 3(Database) test jobs. This patch reduces the total number by 6.

@jc00ke I figure the three remaining rbx-2 test runs still give you what you're looking for, with regards to Rubinius canary projects?