### PR TITLE
Requiring mustache and adding it to engine assets to fix precompile error

### DIFF
--- a/app/assets/javascripts/calagator.js
+++ b/app/assets/javascripts/calagator.js
@@ -2,6 +2,7 @@
 //= require jquery_ujs
 //= require calagator/forms
 //= require leaflet.awesome-markers
+//= require mustache
 
 $(document).ready(function(){
   // Shows hidden section when a link is clicked, and hides the link.

--- a/lib/calagator/engine.rb
+++ b/lib/calagator/engine.rb
@@ -3,7 +3,7 @@ module Calagator
     isolate_namespace Calagator
 
     initializer "calagator.assets.precompile" do |app|
-      app.config.assets.precompile += %w( markers-soft.png markers-shadow.png markers-soft@2x.png markers-shadow@2x.png leaflet.js )
+      app.config.assets.precompile += %w( markers-soft.png markers-shadow.png markers-soft@2x.png markers-shadow@2x.png leaflet.js mustache.js )
     end
   end
 end


### PR DESCRIPTION
I think mustache might only be used for Plancast functionality, and that may be defunct, but it's throwing an error in my dummy app right now and this fixes it.