### PR TITLE
Remove Google Analytics tracking code from engine layout

### DIFF
--- a/app/views/layouts/calagator/_footer_include.html
+++ b/app/views/layouts/calagator/_footer_include.html
@@ -1,0 +1,2 @@
+<%# Override this file to include Javascript in the layout's footer %>
+

--- a/app/views/layouts/calagator/application.html.erb
+++ b/app/views/layouts/calagator/application.html.erb
@@ -43,56 +43,56 @@
   </head>
   <body class="<%= "#{controller.controller_name}_#{action_name}" %> <%= "#{controller.controller_name}_controller" %> <%= %w[new create edit update].include?(action_name) ? "#{controller.controller_name}_change" : "" %>">
 
-  <div id="outer">
-    <div id="global_header">
-      <%= link_to Calagator.title, root_path, id: "project_title" %>
+    <div id="outer">
+      <div id="global_header">
+        <%= link_to Calagator.title, root_path, id: "project_title" %>
 
-      <div id="top_menu">
-         <div id='app_menu'>
-          <ul>
-              <li class='<%=link_class[:events]%>'><%= link_to "Events", events_path %></li>
-              <li class='<%=link_class[:venues]%>'><%= link_to "Venues", venues_path %></li>
-          </ul>
-        </div>
-        <div id='project_menu'>
-          <strong>Get Involved:</strong> <%= link_to "Blog", "http://calagator.wordpress.com/", {:class => 'first'} %> | <%= link_to "Forum", "http://groups.google.com/group/pdx-tech-calendar/" %> | <%= link_to "Code", "https://github.com/calagator/calagator" %>
-          <br />
-          <strong>Something not right?</strong> <%= link_to "File an issue", "https://github.com/calagator/calagator/issues" %>
-        </div>
-        <%= form_tag search_events_path, :method => :get do %>
-          <div id='search_form'>
-          <label for="search_field">Search Events</label>
-          <% if request.env["HTTP_USER_AGENT"] && request.env["HTTP_USER_AGENT"].include?("Safari") %>
-            <input type="search" name="query" value="<%= @query %>" results="5" id="search_field">
-          <% else %>
-            <%= text_field_tag 'query', @query, :id => 'search_field' %>
-          <% end %>
+        <div id="top_menu">
+          <div id='app_menu'>
+            <ul>
+                <li class='<%=link_class[:events]%>'><%= link_to "Events", events_path %></li>
+                <li class='<%=link_class[:venues]%>'><%= link_to "Venues", venues_path %></li>
+            </ul>
           </div>
-        <% end -%>
+          <div id='project_menu'>
+            <strong>Get Involved:</strong> <%= link_to "Blog", "http://calagator.wordpress.com/", {:class => 'first'} %> | <%= link_to "Forum", "http://groups.google.com/group/pdx-tech-calendar/" %> | <%= link_to "Code", "https://github.com/calagator/calagator" %>
+            <br />
+            <strong>Something not right?</strong> <%= link_to "File an issue", "https://github.com/calagator/calagator/issues" %>
+          </div>
+          <%= form_tag search_events_path, :method => :get do %>
+            <div id='search_form'>
+            <label for="search_field">Search Events</label>
+            <% if request.env["HTTP_USER_AGENT"] && request.env["HTTP_USER_AGENT"].include?("Safari") %>
+              <input type="search" name="query" value="<%= @query %>" results="5" id="search_field">
+            <% else %>
+              <%= text_field_tag 'query', @query, :id => 'search_field' %>
+            <% end %>
+            </div>
+          <% end -%>
+        </div>
       </div>
+
+      <% # Pick a subnav %>
+
+      <%= render(:partial => 'calagator/events/subnav') if link_class[:events] == 'active' %>
+      <%= render(:partial => 'calagator/venues/subnav') if link_class[:venues] == 'active' %>
+      <%= render(:partial => 'calagator/sources/subnav') if link_class[:import] == 'active' %>
+
+      <div id="content">
+        <%# flash[:success] = "yay"; flash[:failure] = "meh" %>
+        <%= render_flash %>
+        <%= yield %>
+      </div>
+
+      <div id="top_footer">
+        <%= URI.parse(Calagator.url).host %>
+        <%= source_code_version %>
+        &nbsp;
+        &nbsp;
+        &nbsp;
+      </div>
+
     </div>
-
-    <% # Pick a subnav %>
-
-    <%= render(:partial => 'calagator/events/subnav') if link_class[:events] == 'active' %>
-    <%= render(:partial => 'calagator/venues/subnav') if link_class[:venues] == 'active' %>
-    <%= render(:partial => 'calagator/sources/subnav') if link_class[:import] == 'active' %>
-
-    <div id="content">
-      <%# flash[:success] = "yay"; flash[:failure] = "meh" %>
-      <%= render_flash %>
-      <%= yield %>
-    </div>
-
-    <div id="top_footer">
-      <%= URI.parse(Calagator.url).host %>
-      <%= source_code_version %>
-      &nbsp;
-      &nbsp;
-      &nbsp;
-    </div>
-
-</div>
     <%= render partial: 'layouts/calagator/footer_include' %>
   </body>
 </html>

--- a/app/views/layouts/calagator/application.html.erb
+++ b/app/views/layouts/calagator/application.html.erb
@@ -93,18 +93,7 @@
     </div>
 
 </div>
-
-    <% if Rails.env == 'production' %>
-      <script type="text/javascript">
-        var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
-        document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
-        </script>
-        <script type="text/javascript">
-        var pageTracker = _gat._getTracker("UA-168427-7");
-        pageTracker._initData();
-        pageTracker._trackPageview();
-      </script>
-    <% end %>
-
+    <%= render partial: 'layouts/calagator/footer_include' %>
   </body>
 </html>
+


### PR DESCRIPTION
This should be added by host apps individually by overriding the new `footer_include` partial.

Fixes #376 