### PR TITLE
Filter venues using /venues/tag/:tag

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,7 +37,7 @@ Calagator::Engine.routes.draw do
       get :map
       get :duplicates
       get :autocomplete
-      get 'tag/:tag', to: :search, as: :tag
+      get 'tag/:tag', to: :index, as: :tag
     end
   end
 

--- a/spec/features/filter_venues_spec.rb
+++ b/spec/features/filter_venues_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+feature 'browse venue by tag' do
+  background do
+    create :venue, title: 'Giant Stadium', tag_list: 'old'
+  end
+
+  scenario 'User browses for venue by tag' do
+    visit '/venues/tag/old'
+
+    expect(page).to have_content 'Giant Stadium'
+  end
+
+end


### PR DESCRIPTION
Changed the routing so /venues/tags/:tag went to the index action instead of a search action (there was no search action in the controller.) since the index action already did a search using the params, this lists only the venues that contain that tag.