### PR TITLE
Catch ActiveRecord::StatementInvalid exceptions when searching

### DIFF
--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -98,11 +98,11 @@ class EventsController < Calagator::ApplicationController
   def search
     @search = Event::Search.new(params)
 
-    flash[:failure] = @search.failure_message
-    return redirect_to root_path if @search.hard_failure?
-
     # setting @events so that we can reuse the index atom builder
     @events = @search.events
+
+    flash[:failure] = @search.failure_message
+    return redirect_to root_path if @search.hard_failure?
 
     render_events(@events)
   end

--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -13,6 +13,9 @@ class VenuesController < Calagator::ApplicationController
     @search = Venue::Search.new(params.permit!)
     @venues = @search.venues
 
+    flash[:failure] = @search.failure_message
+    return redirect_to venues_path if @search.hard_failure?
+
     respond_to do |format|
       format.html # index.html.erb
       format.kml  # index.kml.erb

--- a/spec/models/calagator/event/search_spec.rb
+++ b/spec/models/calagator/event/search_spec.rb
@@ -50,6 +50,10 @@ describe Event::Search, :type => :model do
       it "should be a hard failure" do
         expect(event_search).to be_hard_failure
       end
+
+      it "should return no events" do
+        expect(event_search.events).to be_empty
+      end
     end
   end
 
@@ -95,6 +99,10 @@ describe Event::Search, :type => :model do
 
       it "should be a hard failure" do
         expect(event_search).to be_hard_failure
+      end
+
+      it "should return no events" do
+        expect(event_search.events).to be_empty
       end
     end
   end
@@ -149,6 +157,10 @@ describe Event::Search, :type => :model do
       it "should be a hard failure" do
         expect(event_search).to be_hard_failure
       end
+
+      it "should return no events" do
+        expect(event_search.events).to be_empty
+      end
     end
 
     context "when given both search query and tag" do
@@ -160,6 +172,10 @@ describe Event::Search, :type => :model do
 
       it "should be a hard failure" do
         expect(event_search).to be_hard_failure
+      end
+
+      it "should return no events" do
+        expect(event_search.events).to be_empty
       end
     end
   end

--- a/spec/models/calagator/event/search_spec.rb
+++ b/spec/models/calagator/event/search_spec.rb
@@ -3,99 +3,137 @@ require 'spec_helper'
 module Calagator
 
 describe Event::Search, :type => :model do
+  let(:events) { double }
+  before { allow(Event).to receive(:search).and_return(events) }
+  before { allow(Event).to receive(:search_tag).and_return(events) }
+
+  let(:search_params) { {} }
+  subject(:event_search) { Event::Search.new(search_params) }
+
+  before { event_search.events } # fetch the results
+
   describe "by keyword" do
-    it "should be able to only return events that include a specific keyword" do
-      events = double
-      expect(Event).to receive(:search).with("myquery", skip_old: false, order: "date").and_return(events)
+    let(:search_params) { {query: "myquery"} }
 
-      subject = Event::Search.new query: "myquery"
-      expect(subject.events).to eq(events)
+    it "should find all events matching the keyword, ordered by date" do
+      expect(Event).to have_received(:search).with("myquery", skip_old: false, order: "date")
     end
 
-    it "should be able to only return current events" do
-      events = double
-      expect(Event).to receive(:search).with("myquery", order: "date", skip_old: true).and_return(events)
+    context "limited to current events" do
+      let(:search_params) { {query: "myquery", current: "1"} }
 
-      subject = Event::Search.new query: "myquery", current: "1"
-      expect(subject.events).to eq(events)
+      it "should be able to only return current events" do
+        expect(Event).to have_received(:search).with("myquery", order: "date", skip_old: true)
+      end
     end
 
-    it "should warn if user tries ordering by invalid order" do
-      subject = Event::Search.new query: "myquery", order: "kittens"
-      expect(subject.failure_message).to eq("Unknown ordering option \"kittens\", sorting by date instead.")
-      expect(subject).not_to be_hard_failure
+    context "with an invalid order" do
+      let(:search_params) { {query: "myquery", order: "kittens"} }
+
+      it "should set a failure message as a warning" do
+        expect(event_search.failure_message).to eq("Unknown ordering option \"kittens\", sorting by date instead.")
+      end
+
+      it "should not be a hard failure" do
+        expect(event_search).not_to be_hard_failure
+      end
     end
   end
 
   describe "by tag" do
-    it "should be able to only return events matching specific tag" do
-      events = double
-      expect(Event).to receive(:search_tag).with("foo", current: false, order: "date").and_return(events)
+    let(:search_params) { {tag: "foo"} }
 
-      subject = Event::Search.new tag: "foo"
-      expect(subject.events).to eq(events)
+    it "should find all events matching the tag, ordered by date" do
+      expect(Event).to have_received(:search_tag).with("foo", current: false, order: "date")
     end
 
-    it "should warn if user tries ordering by invalid order" do
-      subject = Event::Search.new tag: "omg", order: "kittens"
-      expect(subject.failure_message).to eq("Unknown ordering option \"kittens\", sorting by date instead.")
-      expect(subject).not_to be_hard_failure
+    context "with an invalid order" do
+      let(:search_params) { {tag: "omg", order: "kittens"} }
+
+      it "should set a failure message as a warning" do
+        expect(event_search.failure_message).to eq("Unknown ordering option \"kittens\", sorting by date instead.")
+      end
+
+      it "should not be a hard failure" do
+        expect(subject).not_to be_hard_failure
+      end
     end
 
-    it "should warn if user tries ordering tags by score" do
-      subject = Event::Search.new tag: "omg", order: "score"
-      expect(subject.failure_message).to eq("You cannot sort tags by score")
-      expect(subject).not_to be_hard_failure
+    context "attempting to order by score" do
+      let(:search_params) { {tag: "omg", order: "score"} }
+
+      it "should set a failure message as a warning" do
+        expect(event_search.failure_message).to eq("You cannot sort tags by score")
+      end
+
+      it "should not be a hard failure" do
+        expect(event_search).not_to be_hard_failure
+      end
     end
   end
 
   describe "#grouped_events" do
-    it "groups events into a hash by currentness" do
-      past_event = double(:event, current?: false)
-      current_event = double(:event, current?: true)
-      events = [past_event, current_event]
-      expect(Event).to receive(:search).and_return(events)
+    let(:past_event) { double(:event, current?: false) }
+    let(:current_event) { double(:event, current?: true) }
+    let(:events) { [past_event, current_event] }
+    let(:search_params) { {query: "ruby"} }
 
-      expect(subject.grouped_events).to eq({
+    it "groups events into a hash by currentness" do
+      expect(event_search.grouped_events).to eq({
         past: [past_event],
         current: [current_event],
       })
     end
 
-    it "discards past events when passed the current option" do
-      past_event = double(:event, current?: false)
-      current_event = double(:event, current?: true)
-      events = [past_event, current_event]
-      expect(Event).to receive(:search).and_return(events)
+    context "when passed the 'current' option" do
+      let(:search_params) { {query: "ruby", current: "true"} }
 
-      subject = expect(Event::Search.new(current: "true").grouped_events).to eq({
-        past: [],
-        current: [current_event],
-      })
+      it "discards past events" do
+        expect(event_search.grouped_events).to eq({
+          past: [],
+          current: [current_event],
+        })
+      end
     end
 
-    it "orders past events by date desc if passed date to the order option" do
-      current_event = double(:event, current?: true)
-      past_event = double(:event, current?: false)
-      other_past_event = double(:event, current?: false)
-      expect(Event).to receive(:search).and_return([current_event, past_event, other_past_event])
-      expect(Event::Search.new(order: "date").grouped_events).to eq({
-        current: [current_event],
-        past:    [past_event, other_past_event],
-      })
+    context "when passing 'date' to the order option" do
+      let(:search_params) { {query: "ruby", order: "date"} }
+
+      let(:other_past_event) { double(:event, current?: false) }
+      let(:events) { [current_event, past_event, other_past_event] }
+
+      it "orders past events by date desc" do
+        expect(event_search.grouped_events).to eq({
+          current: [current_event],
+          past:    [past_event, other_past_event],
+        })
+      end
     end
   end
 
   describe "hard failures" do
-    it "should hard fail if given no search query" do
-      expect(subject.failure_message).to eq("You must enter a search query")
-      expect(subject).to be_hard_failure
+    context "when given neither search query nor tag" do
+      let(:search_params) { {} }
+
+      it "should set a failure message" do
+        expect(event_search.failure_message).to eq("You must enter a search query")
+      end
+
+      it "should be a hard failure" do
+        expect(event_search).to be_hard_failure
+      end
     end
 
-    it "should hard fail if searching by both query and tag" do
-      subject = Event::Search.new query: "omg", tag: "bbq"
-      expect(subject.failure_message).to eq("You can't search by tag and query at the same time")
-      expect(subject).to be_hard_failure
+    context "when given both search query and tag" do
+      let(:search_params) { {query: "omg", tag: "bbq"} }
+
+      it "should set a failure message" do
+        expect(event_search.failure_message).to eq("You can't search by tag and query at the same time")
+      end
+
+      it "should be a hard failure" do
+        expect(event_search).to be_hard_failure
+      end
     end
   end
 end

--- a/spec/models/calagator/venue/search_spec.rb
+++ b/spec/models/calagator/venue/search_spec.rb
@@ -86,6 +86,20 @@ describe Venue::Search, :type => :model do
       subject = Venue::Search.new tag: "foo"
       expect(subject.results?).to be_truthy
     end
+
+    describe "handling exceptions" do
+      subject(:venue_search) { Venue::Search.new }
+      before { allow(Venue).to receive(:non_duplicates).and_raise(ActiveRecord::StatementInvalid, "bad times") }
+      before { venue_search.venues }
+
+      it "should set a failure message" do
+        expect(venue_search.failure_message).to eq("There was an error completing your search.")
+      end
+
+      it "should be a hard failure" do
+        expect(venue_search).to be_hard_failure
+      end
+    end
   end
 end
 


### PR DESCRIPTION
One of the most common production exceptions from calagator.org is `ActiveRecord::StatementInvalid` raised by bots trying to exploit our search system. This PR rescues those exceptions and treats them as a hard failure of the search.