### PR TITLE
Remove has_full_address?

### DIFF
--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -121,15 +121,12 @@ class Venue < ActiveRecord::Base
 
   #===[ Address helpers ]=================================================
 
-  # Does this venue have any address information?
-  def has_full_address?
-    [street_address, locality, region, postal_code, country].any?(&:present?)
-  end
-
   # Display a single line address.
   def full_address
-    if has_full_address?
+    if [street_address, locality, region, postal_code, country].any?(&:present?)
       "#{street_address}, #{locality} #{region} #{postal_code} #{country}"
+    else
+      nil
     end
   end
 

--- a/app/views/calagator/events/_feed_item.html.erb
+++ b/app/views/calagator/events/_feed_item.html.erb
@@ -23,7 +23,7 @@
       <% if !event.venue.country.blank? %>
         <div class='country-name'><%= event.venue.country %><div>
       <% end %>
-      <% if event.venue && event.venue.has_full_address? %>
+      <% if event.venue && event.venue.full_address.present? %>
         (<a href='<%=google_maps_url(event.venue.full_address)%>'>map</a>)
       <% end %>
     </div>

--- a/app/views/calagator/events/_hcal.html.erb
+++ b/app/views/calagator/events/_hcal.html.erb
@@ -20,7 +20,7 @@
       <% if !@event.venue.country.blank? -%>
         <div class='country-name'><%= @event.venue.country -%></div>
       <% end -%>
-      <% if @event.venue && @event.venue.has_full_address? -%>
+      <% if @event.venue && @event.venue.full_address.present? -%>
         (<a href='<%=google_maps_url(@event.venue.full_address) -%>'>map</a>)
       <% end -%>
     </div>

--- a/app/views/calagator/events/_item.html.erb
+++ b/app/views/calagator/events/_item.html.erb
@@ -40,7 +40,7 @@ html_classes << " contentbar" if has_contentbar
             <% if !event.venue.country.blank? -%>
             <span class='country-name p-country-name'><%= event.venue.country -%></span>
             <% end -%>
-            <% if event.venue && event.venue.has_full_address? -%>
+            <% if event.venue && event.venue.full_address.present? -%>
             (<a href='<%=google_maps_url(event.venue.full_address) -%>'>map</a>)
             <% end -%>
 

--- a/app/views/calagator/venues/duplicates.html.erb
+++ b/app/views/calagator/venues/duplicates.html.erb
@@ -44,7 +44,7 @@
                 <td><%= venue.events_count %></td>
                 <td>
                   <%= link_to(venue.title, venue_url(venue)) %>
-                  <% if venue.has_full_address? %>
+                  <% if venue.full_address.present? %>
                     at <%= venue.full_address %>
                   <% end %>
                 </td>

--- a/app/views/calagator/venues/index.html.erb
+++ b/app/views/calagator/venues/index.html.erb
@@ -46,7 +46,7 @@
       <% @venues.each do |venue| %>
         <li>
           <%= link_to(venue.title, venue_url(venue)) %>
-          <% if venue.has_full_address? %>
+          <% if venue.full_address.present? %>
             <p class='detail'><%= venue.full_address %></p>
           <% end %>
         </li>

--- a/app/views/calagator/venues/show.html.erb
+++ b/app/views/calagator/venues/show.html.erb
@@ -29,7 +29,7 @@
     <h1 class="fn org"><%= @venue.title %></h1>
     <% if @venue.closed? %><p class='closed_callout'>This venue is no longer open for business.</p><% end %>
 
-    <% if @venue.has_full_address? %>
+    <% if @venue.full_address.present? %>
       <div class="adr">
         <% if @venue.street_address.present? %>
           <div class="street-address"><%= @venue.street_address %></div>


### PR DESCRIPTION
I removed `#has_full_address?` and replaced all instances of it with
`#full_address.present?` based on the conversation in issue #261. Rather
than using compact I stayed with `.any?(&:present?)` since `#compact` would
have considered an empty string as being a valid full_address.

Instead of returning an empty string I returned `nil` so that 
`#geocode_address` would behave as expected.

Fixes #261 