### PR TITLE
Fixing use cases where end date or time are not set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ pkg/
 spec/dummy
 .sass-cache
 .DS_Store
+.idea/*

--- a/app/assets/javascripts/calagator/forms.js
+++ b/app/assets/javascripts/calagator/forms.js
@@ -37,26 +37,23 @@ $(document).on('page:load ready',function(){
 
 // Update "time_end" to maintain the same offset from "time_start" if "time_start" changes, and display a highlight to alert the user.
 $(document).on('change', '#time_start', function() {
-  if ($("#time_end").val()) { // Only update when second input has a value.
-    var duration = ($("#time_end").timepicker('getTime') - oldTime);
-    var newTime = $("#time_start").timepicker('getTime');
-    // Calculate and update the time in the second input.
-    $("#time_end").timepicker('setTime', new Date(newTime.getTime() + duration));
-    $('#time_end').effect('highlight', {}, 3000);
-    oldTime = newTime;
-  }
+  var duration = ($("#time_end").timepicker('getTime') - oldTime);
+  // if the duration is less than 30 minutes, use default duration of an hour
+  if (duration < 1800000) duration = 3600000;
+  var newTime = $("#time_start").timepicker('getTime');
+  // Calculate and update the time in the second input.
+  $("#time_end").timepicker('setTime', new Date(newTime.getTime() + duration));
+  $('#time_end').effect('highlight', {}, 3000);
+  oldTime = newTime;
 });
 
 // Update "date_end" so that it is the same as "date_start" if "date_start" is changed to after "date_end", and displays a highlight to alert the user.
 $(document).on('change', '#date_start, #date_end',function() {
-  // Only update when end value is defined.
-  if ($("#date_end").val()) {
-    // Only update when end value is before start value.
-    var startDate = $.datepicker.parseDate('yy-mm-dd', $('#date_start').val());
-    var endDate = $.datepicker.parseDate('yy-mm-dd', $('#date_end').val());
-    if (endDate < startDate) {
-      $('#date_end').val($('#date_start').val());
-      $('#date_end').effect('highlight', {}, 3000);
-    }
+  // Only update when end value is before start value.
+  var startDate = $.datepicker.parseDate('yy-mm-dd', $('#date_start').val());
+  var endDate = $.datepicker.parseDate('yy-mm-dd', $('#date_end').val());
+  if (endDate < startDate) {
+    $('#date_end').val($('#date_start').val());
+    $('#date_end').effect('highlight', {}, 3000);
   }
 });

--- a/app/helpers/calagator/events_helper.rb
+++ b/app/helpers/calagator/events_helper.rb
@@ -11,6 +11,16 @@ module EventsHelper
     end
   end
 
+  # Cast date to_date unless date is undefined
+  def format_event_date(date)
+    date ? date.to_date : ""
+  end
+
+  # Cast date to time unless date is undefined
+  def format_event_time(date)
+    date ? date.strftime('%I:%M %p') : ""
+  end
+
 # calculate rowspans for an array of events
 # argument:  array of events
 # returns:  rowspans, an array in which each entry corresponds to an event in events;

--- a/app/views/calagator/events/_form.html.erb
+++ b/app/views/calagator/events/_form.html.erb
@@ -27,23 +27,19 @@
       </p>
     <li>
     <li id="event_times" class='input'>
-      <%= f.label :when, "When", :class => 'label' %>
-      <%
-        present = Time.now
-        # Provide initial default values for the start_time and end_time rounded to the upcoming hour.
-        event.start_time ||= present + (60.minutes - present.min.minutes) - present.sec
-        event.end_time   ||= present + (60.minutes - present.min.minutes) - present.sec + 1.hour
-      %>
+      <%= f.label :when, :class => 'label'  do -%>
+        When<abbr title="required">*</abbr>
+      <% end -%>
         <div class="event_start">
-          <%= text_field_tag 'start_date', event.start_time.to_date, :id => 'date_start', :class => 'date_picker' %>
+          <%= text_field_tag 'start_date', format_event_date(event.start_time), :id => 'date_start', :class => 'date_picker' %>
           <span class="at">@</span>
-          <%= text_field_tag 'start_time', event.start_time.strftime('%I:%M %p'), :id => 'time_start', :class => 'time_picker' %>
+          <%= text_field_tag 'start_time', format_event_time(event.start_time), :id => 'time_start', :class => 'time_picker' %>
         </div>
         <span class="to">to</span>
         <div class="event_end">
-          <%= text_field_tag 'end_date', event.end_time.to_date, :id => 'date_end', :class => 'date_picker' %>
+          <%= text_field_tag 'end_date', format_event_date(event.end_time), :id => 'date_end', :class => 'date_picker' %>
           <span class="at">@</span>
-          <%= text_field_tag 'end_time', event.end_time.strftime('%I:%M %p'), :id => 'time_end', :class => 'time_picker' %>
+          <%= text_field_tag 'end_time', format_event_time(event.end_time), :id => 'time_end', :class => 'time_picker' %>
         </div>
         <%= f.semantic_errors :start_date, :start_time, :end_date, :end_time %>
     </li>


### PR DESCRIPTION
This addresses issue #16. 

* For new events, neither start_date/time nor end_date/time will be pre-populated.
* When start_date is set, end_date will be set accordingly even if blank.
* When start_Time is set, end_time will be set accordingly even if blank.
* In cases where there had not been an end_time set, a default duration of an hour is used to populate end_time.
* As start/end are not pre-populated in the view, the to_date and strftime calls would error when either values were blank. To fix, those formatting calls were moved into helpers that only run to_date and strftime when those values are set, and return an empty string if not.

(This request also adds the .idea/ project folder to the .gitignore file for Rubymine users like me. I hope that wasn't presumptuous of me.)