### PR TITLE
Filter events by time

### DIFF
--- a/app/assets/javascripts/calagator/forms.js
+++ b/app/assets/javascripts/calagator/forms.js
@@ -31,6 +31,9 @@ $(document).on('page:load ready',function(){
   // Initialize date and time pickers
   $('.date_picker').datepicker({ dateFormat: 'yy-mm-dd' });
   $('.time_picker').timepicker({ 'timeFormat': 'g:i A' });
+  $('.time_picker_filter').timepicker({
+    'step': 60,
+  });
 
   // Set oldTime to allow time offset functionality
   oldTime = $("#time_start").timepicker('getTime');

--- a/app/assets/stylesheets/calagator/layout.scss
+++ b/app/assets/stylesheets/calagator/layout.scss
@@ -199,8 +199,8 @@ ul.event_list .day_of_week {
 margin-right: 200px;
 }
 
-#list_filters #date_filter label {
-  width: 3em;
+#list_filters label {
+  width: 35%;
   font-weight: normal;
   display: block;
   float: left;
@@ -208,11 +208,11 @@ margin-right: 200px;
   margin-right: 1em;
 }
 
-#list_filters #date_filter input[type=text] {
-  width: 8em;
+#list_filters input[type=text] {
+  width: 55%;
 }
 
-#list_filters #date_filter .clear_filter {
+#list_filters .clear_filter {
   font-size: inherit;
   float: none;
 }

--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -85,6 +85,18 @@ class Event < ActiveRecord::Base
     on_or_after_date(start_date).before_date(end_date)
   }
 
+  scope :before_time, ->(time) {
+    future.order(:start_time).select{|rec| rec.start_time.hour <= time}
+  }
+  scope :after_time, ->(time) {
+    future.order(:start_time).select{|rec| rec.start_time.hour >= time}
+  }
+  scope :within_times, ->(start_time, end_time) {
+    future.order(:start_time).select{|rec|
+      rec.start_time.hour >= start_time && rec.end_time.hour <= end_time
+    }
+  }
+
   scope :future_with_venue, -> {
     future.order("start_time ASC").non_duplicates.includes(:venue)
   }

--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -87,7 +87,7 @@ class Event < ActiveRecord::Base
 
   scope :within_times, ->(start_time, end_time) {
     future.order(:start_time).select{|rec|
-      rec.start_time.hour.between?(start_time,end_time) && rec.end_time.hour.between?(start_time,end_time)
+      rec.start_time.hour.between?(start_time,end_time) && rec.end_time.hour.between?(start_time,end_time-1)
     }
   }
 

--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -85,15 +85,9 @@ class Event < ActiveRecord::Base
     on_or_after_date(start_date).before_date(end_date)
   }
 
-  scope :before_time, ->(time) {
-    future.order(:start_time).select{|rec| rec.start_time.hour <= time}
-  }
-  scope :after_time, ->(time) {
-    future.order(:start_time).select{|rec| rec.start_time.hour >= time}
-  }
   scope :within_times, ->(start_time, end_time) {
     future.order(:start_time).select{|rec|
-      rec.start_time.hour >= start_time && rec.end_time.hour <= end_time
+      rec.start_time.hour.between?(start_time,end_time) && rec.end_time.hour.between?(start_time,end_time)
     }
   }
 

--- a/app/views/calagator/events/index.html.erb
+++ b/app/views/calagator/events/index.html.erb
@@ -11,10 +11,12 @@
 
 <div id='list_filters' class='sidebar'>
 
-  <h3 class='first'>Filter by date</h3>
+  <h3 class='first'>Filter:</h3>
 
   <%= form_tag events_url, :method => 'get' do  -%>
+
   <div id="date_filter">
+    <h4>by date</h4>
     <div id='start_calendar'>
       <label for='date_start'>From</label>
       <%= text_field_tag 'date[start]', @start_date.strftime('%Y-%m-%d'), :id => 'date_start', :class => 'date_picker' %>
@@ -23,16 +25,22 @@
       <label for='date_end'>To</label>
       <%= text_field_tag 'date[end]', @end_date.strftime('%Y-%m-%d'), :id => 'date_end', :class => 'date_picker' %>
     </div>
-    <div>
-    <div id='time_filter'>
-      <%= text_field_tag 'time[start]', @start_time.strftime('%I:%M %p'), :id => 'time_start', :class => 'time_picker' %>
-      <span class="at">@</span>
-      <%= text_field_tag 'time[end]', @end_time.strftime('%I:%M %p'), :id => 'time_end', :class => 'time_picker' %>
-    </div>
-      <label for="commit">&nbsp;</label>
-      <%= submit_tag 'Filter' %>
-      <span class="clear_filter"><%= link_to 'Reset', events_url %></span>
-    </div>
+  </div>
+  <div id='time_filter'>
+  <h4>by time</h4>
+  <div id='start_time_picker'>
+    <label for="time_start">Begins after:</label>
+    <%= text_field_tag 'time[start]', @start_time.strftime('%I:%M %p'), :id => 'filter_time_start', :class => 'time_picker_filter' %>
+  </div>
+  <div id='end_time_picker'>
+    <label for="time_end">Ends before:</label>
+    <%= text_field_tag 'time[end]', @end_time.strftime('%I:%M %p'), :id => 'filter_time_end', :class => 'time_picker_filter' %>
+  </div>
+  </div>
+  <div>
+    <label for="commit">&nbsp;</label>
+    <%= submit_tag 'Filter' %>
+    <span class="clear_filter"><%= link_to 'Reset', events_url %></span>
   </div>
   <% end %>
 

--- a/app/views/calagator/events/index.html.erb
+++ b/app/views/calagator/events/index.html.erb
@@ -10,7 +10,7 @@
 </div>
 
 <div id='list_filters' class='sidebar'>
-  
+
   <h3 class='first'>Filter by date</h3>
 
   <%= form_tag events_url, :method => 'get' do  -%>
@@ -24,13 +24,18 @@
       <%= text_field_tag 'date[end]', @end_date.strftime('%Y-%m-%d'), :id => 'date_end', :class => 'date_picker' %>
     </div>
     <div>
+    <div id='time_filter'>
+      <%= text_field_tag 'time[start]', @start_time.strftime('%I:%M %p'), :id => 'time_start', :class => 'time_picker' %>
+      <span class="at">@</span>
+      <%= text_field_tag 'time[end]', @end_time.strftime('%I:%M %p'), :id => 'time_end', :class => 'time_picker' %>
+    </div>
       <label for="commit">&nbsp;</label>
       <%= submit_tag 'Filter' %>
       <span class="clear_filter"><%= link_to 'Reset', events_url %></span>
     </div>
   </div>
   <% end %>
-  
+
   <h3>Subscribe to</h3>
   <ul>
     <li><%= link_to "iCalendar feed", icalendar_feed_link %></li>
@@ -42,7 +47,7 @@
   <ul>
     <li><%= link_to "iCalendar file", icalendar_export_link %></li>
   </ul>
-  
+
 </div>
 
 <div class='list_items'>

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -516,6 +516,58 @@ describe Event, :type => :model do
     end
   end
 
+  describe "when finding by time" do
+    before do
+      @given_start_time = Time.zone.parse("12:00")
+      @given_end_time = @given_start_time + 5.hours
+      @event_before_time = FactoryGirl.create(:event, start_time: Time.zone.parse("10:00"))
+      @event_after_time = FactoryGirl.create(:event, start_time: Time.zone.parse("14:00"))
+      @event_in_range = FactoryGirl.create(:event, start_time: Time.zone.parse("13:00"), end_time: Time.zone.parse("14:00"))
+    end
+
+    describe "before given time" do
+      before do
+        @events = Event.before_time(@given_start_time)
+      end
+
+      it "should include events with start_time before given time" do
+        expect(@events).to include @event_before_time
+      end
+
+      it "should not include events with start_time after given time" do
+        expect(@events).not_to include(@event_after_time, @event_in_range)
+      end
+    end
+
+    describe "after given time" do
+      before do
+        @events = Event.after_time(@given_start_time)
+      end
+
+      it "should include events with start_time after given time" do
+        expect(@events).to include(@event_after_time, @event_in_range)
+      end
+
+      it "should not include events with start_time before given time" do
+        expect(@events).not_to include(@event_before_time)
+      end
+    end
+
+    describe "within time range" do
+      before do
+        @events = Event.within_times(@given_start_time, @given_end_time)
+      end
+
+      it "should include events with start_time and end_time between given times" do
+        expect(@events).to include(@event_in_range)
+      end
+
+      it "should not include events with start_time and end_time not between given times" do
+        expect(@events).not_to include(@event_before_time)
+      end
+    end
+  end
+
   describe "when ordering" do
     describe "with .ordered_by_ui_field" do
       it "defaults to order by start time" do

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -525,34 +525,6 @@ describe Event, :type => :model do
       @event_in_range = FactoryGirl.create(:event, start_time: Time.zone.parse("13:00"), end_time: Time.zone.parse("14:00"))
     end
 
-    describe "before given time" do
-      before do
-        @events = Event.before_time(@given_start_time.hour)
-      end
-
-      it "should include events with start_time before given time" do
-        expect(@events).to include @event_before_time
-      end
-
-      it "should not include events with start_time after given time" do
-        expect(@events).not_to include(@event_after_time, @event_in_range)
-      end
-    end
-
-    describe "after given time" do
-      before do
-        @events = Event.after_time(@given_start_time.hour)
-      end
-
-      it "should include events with start_time after given time" do
-        expect(@events).to include(@event_after_time, @event_in_range)
-      end
-
-      it "should not include events with start_time before given time" do
-        expect(@events).not_to include(@event_before_time)
-      end
-    end
-
     describe "within time range" do
       before do
         @events = Event.within_times(@given_start_time.hour, @given_end_time.hour)

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -527,7 +527,7 @@ describe Event, :type => :model do
 
     describe "before given time" do
       before do
-        @events = Event.before_time(@given_start_time)
+        @events = Event.before_time(@given_start_time.hour)
       end
 
       it "should include events with start_time before given time" do
@@ -541,7 +541,7 @@ describe Event, :type => :model do
 
     describe "after given time" do
       before do
-        @events = Event.after_time(@given_start_time)
+        @events = Event.after_time(@given_start_time.hour)
       end
 
       it "should include events with start_time after given time" do
@@ -555,7 +555,7 @@ describe Event, :type => :model do
 
     describe "within time range" do
       before do
-        @events = Event.within_times(@given_start_time, @given_end_time)
+        @events = Event.within_times(@given_start_time.hour, @given_end_time.hour)
       end
 
       it "should include events with start_time and end_time between given times" do


### PR DESCRIPTION
I added the ability to filter events given a specific time window from the filter list on the events page. The implementation works well for single day events, but it's not really geared towards multi-day events.