### PR TITLE
Add code to suppress Formtastic deprecation warnings

### DIFF
--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -80,3 +80,21 @@ Formtastic::FormBuilder.all_fields_required_by_default = false
 # end
 # Formtastic::Inputs::Base::Html.send(:include, NoHtmlRequired)
 # Formtastic::Inputs::Base::Html.send(:alias_method_chain, :input_html_options, :no_html_5_required_attribute)
+
+# Formtastic 3.1 deprecated input_class and action_class, and both will be
+#   removed in Formtastic 4.0. This setting, which enables the 4.0 behavior that
+#   was added to 3.1 in preparation for the move to 4.0, prevents a deprecation
+#   warning from spewing during test runs.
+#
+#   More info: https://github.com/justinfrench/formtastic/wiki/Upgrading-to-Formtastic-3.1
+
+require "formtastic/version"
+
+if Formtastic::VERSION.to_f < 4.0
+  Formtastic::FormBuilder.action_class_finder = Formtastic::ActionClassFinder
+  Formtastic::FormBuilder.input_class_finder  = Formtastic::InputClassFinder
+else
+  warn "FIXME: Manual setting of Formtastic::FormBuilder #action_class_finder " +
+         "and #input_class_finder in config/initializers/formtastic.rb can be " +
+         "removed."
+end


### PR DESCRIPTION
Formtastic 3.1 deprecated `input_class` and `action_class`, and both will be removed in Formtastic 4.0. This setting, which enables the 4.0 behavior that was added to 3.1 in preparation for the move to 4.0, prevents a deprecation warning from spewing during test runs.

More info: https://github.com/justinfrench/formtastic/wiki/Upgrading-to-Formtastic-3.1