### PR TITLE
Drop unused reimport column

### DIFF
--- a/app/models/calagator/source.rb
+++ b/app/models/calagator/source.rb
@@ -9,7 +9,6 @@
 #  imported_at :datetime
 #  created_at  :datetime
 #  updated_at  :datetime
-#  reimport    :boolean
 #
 
 # == Source

--- a/app/views/calagator/sources/edit.html.erb
+++ b/app/views/calagator/sources/edit.html.erb
@@ -3,7 +3,6 @@
 <%= semantic_form_for(@source) do |f| %>
   <%= f.inputs do %>
     <%= f.input :url %>
-    <%= f.input :reimport, :label => "Re-import?" %>
   <% end %>
   <%= f.actions :submit %>
 <% end %>

--- a/app/views/calagator/sources/new.html.erb
+++ b/app/views/calagator/sources/new.html.erb
@@ -10,11 +10,6 @@
     </li>
     <%= f.input :url, :label => "URL" %>
     <% focus_on '#source_url' %>
-
-    <%# FIXME Igal has disabled reimport UI because people are adding almost all new events with re-import, which means that they're almost all generating duplicates and I'm completely overwhelmed with having to use the horrible squashing UI to deal with them. %>
-    <% if false %>
-      <%= f.input :reimport, :label => "Re-import?", :hint => "(Regularly check this source and import new events automatically?)" %>
-    <% end %>
   <% end %>
 
   <%= f.actions do %>

--- a/db/migrate/20150702171204_drop_reimport_column_from_sources.rb
+++ b/db/migrate/20150702171204_drop_reimport_column_from_sources.rb
@@ -1,0 +1,9 @@
+class DropReimportColumnFromSources < ActiveRecord::Migration
+  def self.up
+    remove_column :sources, :reimport
+  end
+
+  def self.down
+    add_column :sources, :reimport, :boolean
+  end
+end


### PR DESCRIPTION
I came across the `FIXME` that Igal left in the code back in 2009 while doing some analysis ahead of my OSBridge talk. It appears that the reimport feature hasn't been available when creating new sources for 6.5 years (!) so I removed it just as a decluttering move, but then thought "well gosh, is it being used *anywhere*?" and the answer appears to be "No!" ...and thus a PR was born.