### PR TITLE
Replace find(event) with find(event.id) in spec

### DIFF
--- a/spec/models/calagator/source/parser_ical_spec.rb
+++ b/spec/models/calagator/source/parser_ical_spec.rb
@@ -163,9 +163,9 @@ describe Source::Parser::Ical, "when importing events with non-local times", :ty
 
     # time should be the same after saving event to, and getting it from, database
     event.save
-    e = Event.find(event.id)
-    expect(e.start_time).to eq Time.parse('Thu Jul 01 08:00:00 +0000 2010')
-    expect(e.end_time).to eq Time.parse('Thu Jul 01 09:00:00 +0000 2010')
+    event.reload
+    expect(event.start_time).to eq Time.parse('Thu Jul 01 08:00:00 +0000 2010')
+    expect(event.end_time).to eq Time.parse('Thu Jul 01 09:00:00 +0000 2010')
   end
 
   it "should store time with TZID=GMT in UTC" do

--- a/spec/models/calagator/source/parser_ical_spec.rb
+++ b/spec/models/calagator/source/parser_ical_spec.rb
@@ -163,7 +163,7 @@ describe Source::Parser::Ical, "when importing events with non-local times", :ty
 
     # time should be the same after saving event to, and getting it from, database
     event.save
-    e = Event.find(event)
+    e = Event.find(event.id)
     expect(e.start_time).to eq Time.parse('Thu Jul 01 08:00:00 +0000 2010')
     expect(e.end_time).to eq Time.parse('Thu Jul 01 09:00:00 +0000 2010')
   end


### PR DESCRIPTION
Fix the deprecation warning thrown when running parser_ical_spec.rb by
passing event.id to find rather than passing event itself to
find.