### PR TITLE
Implement search for admin event locking view

### DIFF
--- a/app/assets/stylesheets/calagator/layout.scss
+++ b/app/assets/stylesheets/calagator/layout.scss
@@ -76,6 +76,15 @@ body {
   top: 15px;
 }
 
+#admin_search_form {
+  padding-bottom: 15px;
+}
+
+#admin_search_field {
+  border-radius: 4px;
+  border: 1px solid gray;
+}
+
 .subnav {
   font-size: 1.2em;
   background: $subnav;

--- a/app/controllers/calagator/admin_controller.rb
+++ b/app/controllers/calagator/admin_controller.rb
@@ -1,27 +1,40 @@
 module Calagator
 
-class AdminController < Calagator::ApplicationController
-  require_admin
+  class AdminController < Calagator::ApplicationController
+    require_admin
 
-  def index
-  end
-
-  def events
-    @events = Event.future
-  end
-
-  def lock_event
-    @event = Event.find(params[:event_id])
-    if @event.locked?
-      @event.unlock_editing!
-      flash[:success] = "Unlocked event #{@event.title} (#{@event.id})"
-    else
-      @event.lock_editing!
-      flash[:success] = "Locked event #{@event.title} (#{@event.id})"
+    def index
     end
-    redirect_to :action => :events
-  end
 
-end
+    def events
+      if params[:query].blank?
+        @events = Event.future
+      else
+        @search = Event::Search.new(params)
+        @admin_query = params[:query]
+
+        @events = @search.events
+
+        flash[:failure] = @search.failure_message
+        return redirect_to admin_events_path if @search.hard_failure?
+      end
+
+      render "calagator/admin/events"
+    end
+
+    def lock_event
+      @event = Event.find(params[:event_id])
+
+      if @event.locked?
+        @event.unlock_editing!
+        flash[:success] = "Unlocked event #{@event.title} (#{@event.id})"
+      else
+        @event.lock_editing!
+        flash[:success] = "Locked event #{@event.title} (#{@event.id})"
+      end
+      redirect_to :action => :events, :query => params[:query]
+    end
+
+  end
 
 end

--- a/app/views/calagator/admin/events.html.erb
+++ b/app/views/calagator/admin/events.html.erb
@@ -2,6 +2,15 @@
 
 <p>Locking an event prevents editing or deleting it.</p>
 
+
+<%= form_tag admin_events_path, :method => :get do %>
+  <div id="admin_search_form">
+  <label for="admin_search_field">Search Events</label>
+    <%= search_field_tag "query", @admin_query, :id => "admin_search_field" %>
+    <%= submit_tag("Search") %>
+  </div>
+<% end -%>
+
 <table style="width: 60%; border: 1px solid black;">
   <thead>
     <tr style="background-color: #ccc;">
@@ -17,9 +26,9 @@
       <td style="border: 1px solid gray"><%= event.start_time %></td>
       <td style="border: 1px solid gray">
         <% if event.locked %>
-        <%= button_to "Unlock", lock_event_path(:event_id => event.id) %>
+        <%= button_to "Unlock", lock_event_path(:event_id => event.id, :query => @admin_query) %>
         <% else %>
-        <%= button_to "Lock", lock_event_path(:event_id => event.id) %>
+        <%= button_to "Lock", lock_event_path(:event_id => event.id, :query => @admin_query) %>
         <% end %>
       </td>
     </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Calagator::Engine.routes.draw do
 
   resources :versions, :only => [:edit]
 
-  # Rails 4.0 prevents referencing controllers outside of the Calagator namespace. 
+  # Rails 4.0 prevents referencing controllers outside of the Calagator namespace.
   # Work around this by aliasing PaperTrailManager inside Calagator:
   Calagator::PaperTrailManager ||= ::PaperTrailManager
   resources :changes, controller: 'paper_trail_manager/changes'

--- a/spec/features/admin_search_event_spec.rb
+++ b/spec/features/admin_search_event_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+feature 'Admin lock events search' do
+  background do
+    create :venue, title: 'Empire State Building'
+    create :event, title: 'Ruby Newbies', start_time: Time.zone.now
+    create :event, title: 'Ruby Privateers', start_time: Time.zone.now, locked: true
+
+    page.driver.basic_authorize Calagator.admin_username, Calagator.admin_password
+
+    visit '/admin/events'
+  end
+
+  scenario 'only shows query matches' do
+    fill_in 'admin_search_field', with: 'Privateers'
+
+    click_on 'Search'
+
+    expect(page).to_not have_content('Ruby Newbies')
+    expect(page).to have_content('Ruby Privateers')
+  end
+
+  scenario 'only shows query matches after lock/unlock' do
+    fill_in 'admin_search_field', with: 'Privateers'
+
+    click_on 'Search'
+    click_on 'Unlock'
+
+    expect(page).to have_button('Lock')
+    expect(page).to have_content('Ruby Privateers')
+    expect(page).to_not have_content('Ruby Newbies')
+  end
+end


### PR DESCRIPTION
@jhelwig and I added search functionality to the admin event locking page, but were having trouble getting the tests to work as expected. The tests currently do not pass, and I'm hoping someone can help us troubleshoot them.

It appears to me that the expectations are not waiting until the new page is loaded, because if I check the `page.html` before the expectations, it is incorrect (does not appropriately limit the results on the page), but if I check after the expectations, it appears to only show the search results as expected.

Anyone have thoughts?