### PR TITLE
Fix tags concatenation in edit forms

### DIFF
--- a/app/views/calagator/events/_form.html.erb
+++ b/app/views/calagator/events/_form.html.erb
@@ -54,7 +54,7 @@
     <%= f.input :venue_details, :required => false,
                 :input_html => {:rows => 4},
                 :hint => "(Event-specific details like the room number, or who to call to be let into the building.)" %>
-    <%= f.input :tag_list, :required => false,
+    <%= f.input :tag_list, :input_html => { :value => event.tag_list.to_s }, :required => false,
                 :label => 'Tags',
                 :hint => "(Tags are comma-separated keywords that make it easier to find your event and boost its position in searches. You can also use a tag like <code>plancast:plan=ABCD</code> to associate this with a particular <a href='http://plancast.com/'>Plancast</a> event, or a tag like <code>epdx:group=1234</code> to associate the event with a particular <a href='http://epdx.org/'>ePDX</a> group)".html_safe %>
     <li class='trap'>

--- a/app/views/calagator/venues/_form.html.erb
+++ b/app/views/calagator/venues/_form.html.erb
@@ -30,7 +30,7 @@
 
     <%= f.input(:closed, :label => "This venue is no longer open for business") unless venue.new_record? %>
 
-    <%= f.input :tag_list, :required => false,
+    <%= f.input :tag_list, :input_html => { :value => venue.tag_list.to_s }, :required => false,
                 :label => 'Tags',
                 :hint => "(Tags are comma-separated keywords that make it easier to find your event and boost its position in searches. You can also use a tag like <code>plancast:plan=ABCD</code> to associate this with a particular <a href='http://plancast.com/'>Plancast</a> event, or a tag like <code>epdx:group=1234</code> to associate the event with a particular <a href='http://epdx.org/'>ePDX</a> group)".html_safe %>
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,6 +19,10 @@ FactoryGirl.define do
     wifi true
     access_notes "Access permitted."
     after(:create) { Sunspot.commit if Calagator::Venue::SearchEngine.kind == :sunspot }
+
+    trait :with_multiple_tags do
+      after(:create) { |venue| venue.update_attributes(tag_list: 'tag1, tag2') }
+    end
   end
 
   factory :event, class: Calagator::Event do
@@ -30,6 +34,10 @@ FactoryGirl.define do
 
     trait :with_venue do
       association :venue
+    end
+
+    trait :with_multiple_tags do
+      after(:create) { |event| event.update_attributes(tag_list: 'tag1, tag2') }
     end
   end
 

--- a/spec/features/managing_event_spec.rb
+++ b/spec/features/managing_event_spec.rb
@@ -4,6 +4,7 @@ feature 'Event Editing' do
   background do
     Timecop.travel('2014-10-09')
     create :event, title: 'Ruby Future', start_time: Time.zone.now
+    create :event, :with_multiple_tags, title: 'Tagged Event', start_time: Time.zone.now
   end
 
   after do
@@ -40,6 +41,25 @@ feature 'Event Editing' do
     click_on 'Calagator'
     within '#tomorrow' do
       expect(page).to have_content 'Ruby ABCs'
+    end
+  end
+
+  scenario 'A user edits an event with more than one tag' do
+    visit '/'
+
+    within '#today' do
+      click_on 'Tagged Event'
+    end
+
+    click_on 'edit'
+
+    fill_in 'Event Name', with: 'A Tagged Event'
+    click_on 'Update Event'
+
+    expect(page).to have_content 'tag1, tag2'
+
+    within '.tags' do
+      expect(page).to have_css 'a', count: 2
     end
   end
 end

--- a/spec/features/managing_venue_spec.rb
+++ b/spec/features/managing_venue_spec.rb
@@ -4,6 +4,7 @@ feature 'Venue Editing' do
   let!(:venue) { create(:venue) }
   let!(:event) { create(:event, venue: venue, start_time: Time.now.end_of_day - 1.hour) }
   let!(:new_venue) { build(:venue) }
+  let!(:venue_with_tags) {create(:venue, :with_multiple_tags)}
 
   scenario 'A user edits an existing venue' do
 
@@ -44,6 +45,27 @@ feature 'Venue Editing' do
     expect(page).to have_content 'Public WiFi'
     expect(page).to have_content 'Just pay the ticket price.'
     expect(page).to have_content 'This venue is no longer open for business.' if new_venue.closed
+  end
+
+  scenario 'A user edits a venue with more than one tag' do
+    visit '/'
+
+    click_on 'Venues'
+
+    within '#newest' do
+      click_on venue_with_tags.title
+    end
+
+    click_on 'edit'
+
+    fill_in 'Venue Name', with: 'A Tagged Venue'
+    click_on 'Update Venue'
+
+    expect(page).to have_content 'tag1, tag2'
+
+    within '.tags' do
+      expect(page).to have_css 'a', count: 2
+    end
   end
 end
 


### PR DESCRIPTION
For some reason involving the acts_as_taggable_on gem and Rails 4.2 ([#676](https://github.com/mbleigh/acts-as-taggable-on/issues/676)), tag names were being concatenated in event and venue edit forms. e.g. tag1, tag2 => tag1 tag2. So in editing, a user could inadvertently combine two tags into one.

My attempt at fixing the issue is to manually set the tag_list input value by calling tag_list.to_s on the model.

Let me know if I need to take a different approach.