### PR TITLE
Extract Event::Browse from EventsController#index

### DIFF
--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -17,20 +17,8 @@ class EventsController < Calagator::ApplicationController
 
     browse = Event::Browse.new(params, @start_date, @end_date)
     @events = browse.events
-
-   if (time = params[:time])
-     if (parsed_start_time = Time.zone.parse(time[:start]) and parsed_end_time = Time.zone.parse(time[:end]))
-       @events = @events.within_times(parsed_start_time.hour, parsed_end_time.hour)
-       @start_time = parsed_start_time.strftime('%I:%M %p')
-       @end_time = parsed_end_time.strftime('%I:%M %p')
-     elsif (parsed_start_time = Time.zone.parse(time[:start]))
-       @events = @events.after_time(parsed_start_time.hour)
-       @start_time = parsed_start_time.strftime('%I:%M %p')
-     elsif (parsed_end_time = Time.zone.parse(time[:end]))
-       @events = @events.before_time(parsed_end_time.hour)
-       @end_time = parsed_end_time.strftime('%I:%M %p')
-     end
-   end
+    @start_time = browse.start_time
+    @end_time = browse.end_time
 
     @perform_caching = params[:order].blank? && params[:date].blank?
 

--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -12,13 +12,15 @@ class EventsController < Calagator::ApplicationController
   # GET /events
   # GET /events.xml
   def index
-    browse = Event::Browse.new(params, self)
+    browse = Event::Browse.new(params)
 
     @events = browse.events
     @start_date = browse.start_date
     @end_date = browse.end_date
     @start_time = browse.start_time
     @end_time = browse.end_time
+
+    browse.errors.each { |error| append_flash :failure, error }
 
     @perform_caching = params[:order].blank? && params[:date].blank?
 

--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -12,11 +12,11 @@ class EventsController < Calagator::ApplicationController
   # GET /events
   # GET /events.xml
   def index
-    @start_date = date_or_default_for(:start)
-    @end_date = date_or_default_for(:end)
+    browse = Event::Browse.new(params, self)
 
-    browse = Event::Browse.new(params, @start_date, @end_date)
     @events = browse.events
+    @start_date = browse.start_date
+    @end_date = browse.end_date
     @start_time = browse.start_time
     @end_time = browse.end_time
 
@@ -134,30 +134,6 @@ class EventsController < Calagator::ApplicationController
       format.xml  { render :xml  => events.to_xml(root: "events", :include => :venue) }
       format.json { render :json => events.to_json(:include => :venue), :callback => params[:callback] }
     end
-  end
-
-  # Return the default start date.
-  def default_start_date
-    Time.zone.today
-  end
-
-  # Return the default end date.
-  def default_end_date
-    Time.zone.today + 3.months
-  end
-
-
-  # Return a date parsed from user arguments or a default date. The +kind+
-  # is a value like :start, which refers to the `params[:date][+kind+]` value.
-  # If there's an error, set an error message to flash.
-  def date_or_default_for(kind)
-    default = send("default_#{kind}_date")
-    return default unless params[:date].present?
-
-    Date.parse(params[:date][kind])
-  rescue NoMethodError, ArgumentError, TypeError
-    append_flash :failure, "Can't filter by an invalid #{kind} date."
-    default
   end
 
   def find_and_redirect_if_locked

--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -15,10 +15,8 @@ class EventsController < Calagator::ApplicationController
     @start_date = date_or_default_for(:start)
     @end_date = date_or_default_for(:end)
 
-    query = Event.non_duplicates.ordered_by_ui_field(params[:order]).includes(:venue, :tags)
-    @events = params[:date] ?
-                query.within_dates(@start_date, @end_date) :
-                query.future
+    browse = Event::Browse.new(params, @start_date, @end_date)
+    @events = browse.events
 
    if (time = params[:time])
      if (parsed_start_time = Time.zone.parse(time[:start]) and parsed_end_time = Time.zone.parse(time[:end]))

--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -12,18 +12,10 @@ class EventsController < Calagator::ApplicationController
   # GET /events
   # GET /events.xml
   def index
-    browse = Event::Browse.new(params)
-
-    @events = browse.events
-    @start_date = browse.start_date
-    @end_date = browse.end_date
-    @start_time = browse.start_time
-    @end_time = browse.end_time
-
-    browse.errors.each { |error| append_flash :failure, error }
-
+    @browse = Event::Browse.new(params)
+    @events = @browse.events
+    @browse.errors.each { |error| append_flash :failure, error }
     @perform_caching = params[:order].blank? && params[:date].blank?
-
     render_events @events
   end
 

--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -15,7 +15,6 @@ class EventsController < Calagator::ApplicationController
     @browse = Event::Browse.new(params)
     @events = @browse.events
     @browse.errors.each { |error| append_flash :failure, error }
-    @perform_caching = params[:order].blank? && params[:date].blank?
     render_events @events
   end
 

--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -85,22 +85,6 @@ class Event < ActiveRecord::Base
     on_or_after_date(start_date).before_date(end_date)
   }
 
-  scope :within_times, ->(start_time, end_time) {
-    order(:start_time).select{|rec|
-      rec.start_time.hour > start_time && rec.end_time.hour < end_time
-    }
-  }
-  scope :before_time, ->(end_time) {
-    order(:end_time).select{|rec|
-      rec.end_time.hour < end_time
-    }
-  }
-  scope :after_time, ->(start_time) {
-    order(:start_time).select{|rec|
-      rec.start_time.hour >= start_time
-    }
-  }
-
   scope :future_with_venue, -> {
     future.order("start_time ASC").non_duplicates.includes(:venue)
   }

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -1,35 +1,16 @@
 module Calagator
   class Event < ActiveRecord::Base
     class Browse < Struct.new(:params, :controller)
-      attr_reader :start_date, :end_date
-
-      # Return the default start date.
-      def default_start_date
-        Time.zone.today
-      end
-
-      # Return the default end date.
-      def default_end_date
-        Time.zone.today + 3.months
-      end
-
-      # Return a date parsed from user arguments or a default date. The +kind+
-      # is a value like :start, which refers to the `params[:date][+kind+]` value.
-      # If there's an error, set an error message to flash.
-      def date_or_default_for(kind)
-        default = send("default_#{kind}_date")
-        return default unless params[:date].present?
-
-        Date.parse(params[:date][kind])
-      rescue NoMethodError, ArgumentError, TypeError
-        controller.send :append_flash, :failure, "Can't filter by an invalid #{kind} date."
-        default
-      end
-
       def events
-        @start_date = date_or_default_for(:start)
-        @end_date = date_or_default_for(:end)
         order.filter_by_date.filter_by_time.scope
+      end
+
+      def start_date
+        date_or_default_for(:start)
+      end
+
+      def end_date
+        date_or_default_for(:end)
       end
 
       def start_time
@@ -72,6 +53,24 @@ module Calagator
       end
 
       private
+
+      def default_start_date
+        Time.zone.today
+      end
+
+      def default_end_date
+        Time.zone.today + 3.months
+      end
+
+      def date_or_default_for(kind)
+        default = send("default_#{kind}_date")
+        return default unless params[:date].present?
+
+        Date.parse(params[:date][kind])
+      rescue NoMethodError, ArgumentError, TypeError
+        controller.send :append_flash, :failure, "Can't filter by an invalid #{kind} date."
+        default
+      end
 
       def parsed_start_time
         Time.zone.parse(params[:time][:start]) rescue nil

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -40,20 +40,20 @@ module Calagator
       end
 
       def within_times(scope, start_time, end_time)
-        scope.order(:start_time).select do |rec|
-          rec.start_time.hour > start_time.hour && rec.end_time.hour < end_time.hour
+        scope.order(:start_time).select do |event|
+          event.start_time.hour > start_time.hour && event.end_time.hour < end_time.hour
         end
       end
 
       def before_time(scope, end_time)
-        scope.order(:end_time).select do |rec|
-          rec.end_time.hour < end_time.hour
+        scope.order(:end_time).select do |event|
+          event.end_time.hour < end_time.hour
         end
       end
 
       def after_time(scope, start_time)
-        scope.order(:start_time).select do |rec|
-          rec.start_time.hour >= start_time.hour
+        scope.order(:start_time).select do |event|
+          event.start_time.hour >= start_time.hour
         end
       end
     end

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -1,0 +1,14 @@
+module Calagator
+  class Event < ActiveRecord::Base
+    class Browse < Struct.new(:params, :start_date, :end_date)
+      def events
+        query = Event.non_duplicates.ordered_by_ui_field(params[:order]).includes(:venue, :tags)
+        if params[:date]
+          query.within_dates(start_date, end_date)
+        else
+          query.future
+        end
+      end
+    end
+  end
+end

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -12,11 +12,11 @@ module Calagator
       end
 
       def start_date
-        date_for(:start) || Time.zone.today
+        date_for(:start).strftime('%Y-%m-%d')
       end
 
       def end_date
-        date_for(:end) || Time.zone.today + 3.months
+        date_for(:end).strftime('%Y-%m-%d')
       end
 
       def start_time
@@ -48,7 +48,7 @@ module Calagator
 
       def filter_by_date
         @scope = if date
-          scope.within_dates(start_date, end_date)
+          scope.within_dates(date_for(:start), date_for(:end))
         else
           scope.future
         end
@@ -63,12 +63,16 @@ module Calagator
 
       private
 
+      def default_date_for(kind)
+        kind == :start ? Time.zone.today : Time.zone.today + 3.months
+      end
+
       def date_for(kind)
-        return unless date.present?
+        return default_date_for(kind) unless date.present?
         Date.parse(date[kind])
       rescue NoMethodError, ArgumentError, TypeError
         errors << "Can't filter by an invalid #{kind} date."
-        nil
+        default_date_for(kind)
       end
 
       def time_for(kind)

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -11,11 +11,11 @@ module Calagator
         end
 
         if parsed_start_time && parsed_end_time
-          scope = within_times(scope, parsed_start_time.hour, parsed_end_time.hour)
+          scope = within_times(scope, parsed_start_time, parsed_end_time)
         elsif parsed_start_time
-          scope = after_time(scope, parsed_start_time.hour)
+          scope = after_time(scope, parsed_start_time)
         elsif parsed_end_time
-          scope = before_time(scope, parsed_end_time.hour)
+          scope = before_time(scope, parsed_end_time)
         end
 
         scope
@@ -41,19 +41,19 @@ module Calagator
 
       def within_times(scope, start_time, end_time)
         scope.order(:start_time).select do |rec|
-          rec.start_time.hour > start_time && rec.end_time.hour < end_time
+          rec.start_time.hour > start_time.hour && rec.end_time.hour < end_time.hour
         end
       end
 
       def before_time(scope, end_time)
         scope.order(:end_time).select do |rec|
-          rec.end_time.hour < end_time
+          rec.end_time.hour < end_time.hour
         end
       end
 
       def after_time(scope, start_time)
         scope.order(:start_time).select do |rec|
-          rec.start_time.hour >= start_time
+          rec.start_time.hour >= start_time.hour
         end
       end
     end

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -1,6 +1,6 @@
 module Calagator
   class Event < ActiveRecord::Base
-    class Browse < Struct.new(:params, :controller)
+    class Browse < Struct.new(:params)
       def events
         order.filter_by_date.filter_by_time.scope
       end
@@ -19,6 +19,10 @@ module Calagator
 
       def end_time
         parsed_end_time.strftime('%I:%M %p') if parsed_end_time
+      end
+
+      def errors
+        @errors ||= []
       end
 
       protected
@@ -68,7 +72,7 @@ module Calagator
 
         Date.parse(params[:date][kind])
       rescue NoMethodError, ArgumentError, TypeError
-        controller.send :append_flash, :failure, "Can't filter by an invalid #{kind} date."
+        errors << "Can't filter by an invalid #{kind} date."
         default
       end
 

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -1,13 +1,32 @@
 module Calagator
   class Event < ActiveRecord::Base
     class Browse < Struct.new(:params, :start_date, :end_date)
+      attr_reader :start_time, :end_time
+
       def events
-        query = Event.non_duplicates.ordered_by_ui_field(params[:order]).includes(:venue, :tags)
-        if params[:date]
-          query.within_dates(start_date, end_date)
+        scope = Event.non_duplicates.ordered_by_ui_field(params[:order]).includes(:venue, :tags)
+
+        scope = if params[:date]
+          scope.within_dates(start_date, end_date)
         else
-          query.future
+          scope.future
         end
+
+        if (time = params[:time])
+          if (parsed_start_time = Time.zone.parse(time[:start]) and parsed_end_time = Time.zone.parse(time[:end]))
+            scope = scope.within_times(parsed_start_time.hour, parsed_end_time.hour)
+            @start_time = parsed_start_time.strftime('%I:%M %p')
+            @end_time = parsed_end_time.strftime('%I:%M %p')
+          elsif (parsed_start_time = Time.zone.parse(time[:start]))
+            scope = scope.after_time(parsed_start_time.hour)
+            @start_time = parsed_start_time.strftime('%I:%M %p')
+          elsif (parsed_end_time = Time.zone.parse(time[:end]))
+            scope = scope.before_time(parsed_end_time.hour)
+            @end_time = parsed_end_time.strftime('%I:%M %p')
+          end
+        end
+
+        scope
       end
     end
   end

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -46,13 +46,8 @@ module Calagator
       end
 
       def filter_by_time
-        if time_for(:start) && time_for(:end)
-          @scope = within_times(scope, time_for(:start), time_for(:end))
-        elsif time_for(:start)
-          @scope = after_time(scope, time_for(:start))
-        elsif time_for(:end)
-          @scope = before_time(scope, time_for(:end))
-        end
+        @scope = after_time if time_for(:start)
+        @scope = before_time if time_for(:end)
         self
       end
 
@@ -70,22 +65,12 @@ module Calagator
         Time.zone.parse(params[:time][kind]) rescue nil
       end
 
-      def within_times(scope, start_time, end_time)
-        scope.order(:start_time).select do |event|
-          event.start_time.hour > start_time.hour && event.end_time.hour < end_time.hour
-        end
+      def before_time
+        scope.select { |event| event.end_time.hour <= time_for(:end).hour }
       end
 
-      def before_time(scope, end_time)
-        scope.order(:end_time).select do |event|
-          event.end_time.hour < end_time.hour
-        end
-      end
-
-      def after_time(scope, start_time)
-        scope.order(:start_time).select do |event|
-          event.start_time.hour >= start_time.hour
-        end
+      def after_time
+        scope.select { |event| event.start_time.hour >= time_for(:start).hour }
       end
     end
   end

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -11,11 +11,11 @@ module Calagator
         end
 
         if parsed_start_time && parsed_end_time
-          scope = scope.within_times(parsed_start_time.hour, parsed_end_time.hour)
+          scope = within_times(scope, parsed_start_time.hour, parsed_end_time.hour)
         elsif parsed_start_time
-          scope = scope.after_time(parsed_start_time.hour)
+          scope = after_time(scope, parsed_start_time.hour)
         elsif parsed_end_time
-          scope = scope.before_time(parsed_end_time.hour)
+          scope = before_time(scope, parsed_end_time.hour)
         end
 
         scope
@@ -37,6 +37,24 @@ module Calagator
 
       def parsed_end_time
         Time.zone.parse(params[:time][:end]) rescue nil
+      end
+
+      def within_times(scope, start_time, end_time)
+        scope.order(:start_time).select do |rec|
+          rec.start_time.hour > start_time && rec.end_time.hour < end_time
+        end
+      end
+
+      def before_time(scope, end_time)
+        scope.order(:end_time).select do |rec|
+          rec.end_time.hour < end_time
+        end
+      end
+
+      def after_time(scope, start_time)
+        scope.order(:start_time).select do |rec|
+          rec.start_time.hour >= start_time
+        end
       end
     end
   end

--- a/app/views/calagator/events/index.html.erb
+++ b/app/views/calagator/events/index.html.erb
@@ -19,22 +19,22 @@
     <h4>by date</h4>
     <div id='start_calendar'>
       <label for='date_start'>From</label>
-      <%= text_field_tag 'date[start]', @start_date.strftime('%Y-%m-%d'), :id => 'date_start', :class => 'date_picker' %>
+      <%= text_field_tag 'date[start]', @browse.start_date.strftime('%Y-%m-%d'), :id => 'date_start', :class => 'date_picker' %>
     </div>
     <div id='end_calendar'>
       <label for='date_end'>To</label>
-      <%= text_field_tag 'date[end]', @end_date.strftime('%Y-%m-%d'), :id => 'date_end', :class => 'date_picker' %>
+      <%= text_field_tag 'date[end]', @browse.end_date.strftime('%Y-%m-%d'), :id => 'date_end', :class => 'date_picker' %>
     </div>
   </div>
   <div id='time_filter'>
   <h4>by time</h4>
     <div id='start_time_picker'>
       <label for="time_start">Begins after:</label>
-      <%= text_field_tag 'time[start]', @start_time, :id => 'filter_time_start', :class => 'time_picker_filter' %>
+      <%= text_field_tag 'time[start]', @browse.start_time, :id => 'filter_time_start', :class => 'time_picker_filter' %>
     </div>
     <div id='end_time_picker'>
       <label for="time_end">Ends before:</label>
-      <%= text_field_tag 'time[end]', @end_time, :id => 'filter_time_end', :class => 'time_picker_filter' %>
+      <%= text_field_tag 'time[end]', @browse.end_time, :id => 'filter_time_end', :class => 'time_picker_filter' %>
     </div>
   </div>
   <div>

--- a/app/views/calagator/events/index.html.erb
+++ b/app/views/calagator/events/index.html.erb
@@ -2,11 +2,11 @@
 
 <% tabindex_on '#search_field' %>
 
-<% cache_if(@perform_caching, Calagator::CacheObserver.daily_key_for("events_index", request)) do %>
+<% cache_if(@browse.default?, Calagator::CacheObserver.daily_key_for("events_index", request)) do %>
 <div class='list_description'>
-  <h2>Viewing <strong><%= @events.size %></strong>
-  <%= params[:date] ? 'filtered' : 'future' %> events
-  <%= events_sort_label(params[:order]) %></h2>
+  <h2>Viewing <strong><%= @browse.events.size %></strong>
+  <%= @browse.date ? 'filtered' : 'future' %> events
+  <%= events_sort_label(@browse.order) %></h2>
 </div>
 
 <div id='list_filters' class='sidebar'>
@@ -59,6 +59,6 @@
 </div>
 
 <div class='list_items'>
-  <%= render :partial => 'table', :locals => { :events => @events } %>
+  <%= render :partial => 'table', :locals => { :events => @browse.events } %>
 </div>
 <% end %>

--- a/app/views/calagator/events/index.html.erb
+++ b/app/views/calagator/events/index.html.erb
@@ -19,11 +19,11 @@
     <h4>by date</h4>
     <div id='start_calendar'>
       <label for='date_start'>From</label>
-      <%= text_field_tag 'date[start]', @browse.start_date.strftime('%Y-%m-%d'), :id => 'date_start', :class => 'date_picker' %>
+      <%= text_field_tag 'date[start]', @browse.start_date, :id => 'date_start', :class => 'date_picker' %>
     </div>
     <div id='end_calendar'>
       <label for='date_end'>To</label>
-      <%= text_field_tag 'date[end]', @browse.end_date.strftime('%Y-%m-%d'), :id => 'date_end', :class => 'date_picker' %>
+      <%= text_field_tag 'date[end]', @browse.end_date, :id => 'date_end', :class => 'date_picker' %>
     </div>
   </div>
   <div id='time_filter'>

--- a/spec/controllers/calagator/events_controller_spec.rb
+++ b/spec/controllers/calagator/events_controller_spec.rb
@@ -206,8 +206,8 @@ describe EventsController, :type => :controller do
     describe "and filtering by date range" do
       [:start, :end].each do |date_kind|
         describe "for #{date_kind} date" do
-          let(:start_date) { Date.parse("2010-01-01") }
-          let(:end_date) { Date.parse("2010-04-01") }
+          let(:start_date) { "2010-01-01" }
+          let(:end_date) { "2010-04-01" }
           let(:date_field) { "#{date_kind}_date" }
 
           around do |example|
@@ -247,8 +247,8 @@ describe EventsController, :type => :controller do
           end
 
           it "should use the value if valid" do
-            expected = Date.yesterday
-            get :index, :date => {date_kind => expected.to_s("%Y-%m-%d")}
+            expected = Date.yesterday.to_s("%Y-%m-%d")
+            get :index, :date => {date_kind => expected}
             expect(assigns[:browse].send(date_field)).to eq expected
           end
         end

--- a/spec/controllers/calagator/events_controller_spec.rb
+++ b/spec/controllers/calagator/events_controller_spec.rb
@@ -218,38 +218,38 @@ describe EventsController, :type => :controller do
 
           it "should use the default if not given the parameter" do
             get :index, :date => {}
-            expect(assigns[date_field]).to eq send(date_field)
+            expect(assigns[:browse].send(date_field)).to eq send(date_field)
             expect(flash[:failure]).to be_nil
           end
 
           it "should use the default if given a malformed parameter" do
             get :index, :date => "omgkittens"
-            expect(assigns[date_field]).to eq send(date_field)
+            expect(assigns[:browse].send(date_field)).to eq send(date_field)
             expect(response.body).to have_selector(".flash_failure", text: 'invalid')
           end
 
           it "should use the default if given a missing parameter" do
             get :index, :date => {:foo => "bar"}
-            expect(assigns[date_field]).to eq send(date_field)
+            expect(assigns[:browse].send(date_field)).to eq send(date_field)
             expect(response.body).to have_selector(".flash_failure", text: 'invalid')
           end
 
           it "should use the default if given an empty parameter" do
             get :index, :date => {date_kind => ""}
-            expect(assigns[date_field]).to eq send(date_field)
+            expect(assigns[:browse].send(date_field)).to eq send(date_field)
             expect(response.body).to have_selector(".flash_failure", text: 'invalid')
           end
 
           it "should use the default if given an invalid parameter" do
             get :index, :date => {date_kind => "omgkittens"}
-            expect(assigns[date_field]).to eq send(date_field)
+            expect(assigns[:browse].send(date_field)).to eq send(date_field)
             expect(response.body).to have_selector(".flash_failure", text: 'invalid')
           end
 
           it "should use the value if valid" do
             expected = Date.yesterday
             get :index, :date => {date_kind => expected.to_s("%Y-%m-%d")}
-            expect(assigns[date_field]).to eq expected
+            expect(assigns[:browse].send(date_field)).to eq expected
           end
         end
       end

--- a/spec/controllers/calagator/events_controller_spec.rb
+++ b/spec/controllers/calagator/events_controller_spec.rb
@@ -204,90 +204,33 @@ describe EventsController, :type => :controller do
     end
 
     describe "and filtering by date range" do
-      [:start, :end].each do |date_kind|
-        describe "for #{date_kind} date" do
-          let(:start_date) { "2010-01-01" }
-          let(:end_date) { "2010-04-01" }
-          let(:date_field) { "#{date_kind}_date" }
+      let!(:within) { [
+        Event.create!(
+          title: "matching1",
+          start_time: Time.zone.parse("2010-01-16 00:00"),
+          end_time: Time.zone.parse("2010-01-16 01:00")
+        ),
+      ] }
 
-          around do |example|
-            Timecop.freeze(start_date) do
-              example.run
-            end
-          end
+      let!(:before) { [
+        Event.create!(
+          title: "nonmatchingbefore",
+          start_time: Time.zone.parse("2010-01-15 23:00"),
+          end_time: Time.zone.parse("2010-01-15 23:59")
+        ),
+      ] }
 
-          it "should use the default if not given the parameter" do
-            get :index, :date => {}
-            expect(assigns[:browse].send(date_field)).to eq send(date_field)
-            expect(flash[:failure]).to be_nil
-          end
-
-          it "should use the default if given a malformed parameter" do
-            get :index, :date => "omgkittens"
-            expect(assigns[:browse].send(date_field)).to eq send(date_field)
-            expect(response.body).to have_selector(".flash_failure", text: 'invalid')
-          end
-
-          it "should use the default if given a missing parameter" do
-            get :index, :date => {:foo => "bar"}
-            expect(assigns[:browse].send(date_field)).to eq send(date_field)
-            expect(response.body).to have_selector(".flash_failure", text: 'invalid')
-          end
-
-          it "should use the default if given an empty parameter" do
-            get :index, :date => {date_kind => ""}
-            expect(assigns[:browse].send(date_field)).to eq send(date_field)
-            expect(response.body).to have_selector(".flash_failure", text: 'invalid')
-          end
-
-          it "should use the default if given an invalid parameter" do
-            get :index, :date => {date_kind => "omgkittens"}
-            expect(assigns[:browse].send(date_field)).to eq send(date_field)
-            expect(response.body).to have_selector(".flash_failure", text: 'invalid')
-          end
-
-          it "should use the value if valid" do
-            expected = Date.yesterday.to_s("%Y-%m-%d")
-            get :index, :date => {date_kind => expected}
-            expect(assigns[:browse].send(date_field)).to eq expected
-          end
-        end
-      end
+      let!(:after) { [
+        Event.create!(
+          title: "nonmatchingafter",
+          start_time: Time.zone.parse("2010-01-17 00:01"),
+          end_time: Time.zone.parse("2010-01-17 01:00")
+        ),
+      ] }
 
       it "should return matching events" do
-        # Given
-        matching = [
-          Event.create!(
-            :title => "matching1",
-            :start_time => Time.zone.parse("2010-01-16 00:00"),
-            :end_time => Time.zone.parse("2010-01-16 01:00")
-          ),
-          Event.create!(:title => "matching2",
-            :start_time => Time.zone.parse("2010-01-16 23:00"),
-            :end_time => Time.zone.parse("2010-01-17 00:00")
-          ),
-        ]
-
-        non_matching = [
-          Event.create!(
-            :title => "nonmatchingbefore",
-            :start_time => Time.zone.parse("2010-01-15 23:00"),
-            :end_time => Time.zone.parse("2010-01-15 23:59")
-          ),
-          Event.create!(
-            :title => "nonmatchingafter",
-            :start_time => Time.zone.parse("2010-01-17 00:01"),
-            :end_time => Time.zone.parse("2010-01-17 01:00")
-          ),
-        ]
-
-        # When
-        get :index, :date => {:start => "2010-01-16", :end => "2010-01-16"}
-        results = assigns[:events]
-
-        # Then
-        expect(results.size).to eq 2
-        expect(results).to eq matching
+        get :index, date: { start: "2010-01-16", end: "2010-01-16" }
+        expect(assigns[:events]).to eq within
       end
     end
 

--- a/spec/models/calagator/event/browse_spec.rb
+++ b/spec/models/calagator/event/browse_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+module Calagator
+  describe Event::Browse do
+    describe "when finding by time" do
+      before do
+        @given_start_time = Time.zone.parse("12:00")
+        @given_end_time = Time.zone.parse("17:00")
+        @event_before_end_time = FactoryGirl.create(:event,
+                                                    start_time: Time.zone.parse("10:00"),
+                                                    end_time: Time.zone.parse("14:00"))
+        @event_after_start_time = FactoryGirl.create(:event,
+                                                     start_time: Time.zone.parse("14:00"),
+                                                     end_time: Time.zone.parse("18:00"))
+        @event_in_range = FactoryGirl.create(:event,
+                                             start_time: Time.zone.parse("13:00"),
+                                             end_time: Time.zone.parse("14:00"))
+      end
+
+      describe "before time" do
+        before do
+          @events = Event::Browse.new(time: { end: @given_end_time.strftime('%I:%M %p') }).events
+        end
+
+        it "should include events with end_time before given end time" do
+          expect(@events).to include(@event_before_end_time, @event_in_range)
+        end
+
+        it "should not include events with end_time after given end time" do
+          expect(@events).not_to include(@event_after_start_time)
+        end
+      end
+
+      describe "after time" do
+        before do
+          @events = Event::Browse.new(time: { start: @given_start_time.strftime('%I:%M %p') }).events
+        end
+
+        it "should include events with start_time after given start time" do
+          expect(@events).to include(@event_after_start_time, @event_in_range)
+        end
+
+        it "should not include events with start_time before given start time" do
+          expect(@events).not_to include(@event_before_end_time)
+        end
+      end
+
+      describe "within time range" do
+        before do
+          @events = Event::Browse.new(time: {
+            start: @given_start_time.strftime('%I:%M %p'),
+            end: @given_end_time.strftime('%I:%M %p'),
+          }).events
+        end
+
+        it "should include events with start_time and end_time between given times" do
+          expect(@events).to include(@event_in_range)
+        end
+
+        it "should not include events with start_time and end_time not between given times" do
+          expect(@events).not_to include(@event_before_end_time)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/calagator/event/browse_spec.rb
+++ b/spec/models/calagator/event/browse_spec.rb
@@ -2,64 +2,187 @@ require 'spec_helper'
 
 module Calagator
   describe Event::Browse do
-    describe "when finding by time" do
-      before do
-        @given_start_time = Time.zone.parse("12:00")
-        @given_end_time = Time.zone.parse("17:00")
-        @event_before_end_time = FactoryGirl.create(:event,
-                                                    start_time: Time.zone.parse("10:00"),
-                                                    end_time: Time.zone.parse("14:00"))
-        @event_after_start_time = FactoryGirl.create(:event,
-                                                     start_time: Time.zone.parse("14:00"),
-                                                     end_time: Time.zone.parse("18:00"))
-        @event_in_range = FactoryGirl.create(:event,
-                                             start_time: Time.zone.parse("13:00"),
-                                             end_time: Time.zone.parse("14:00"))
+    describe "when filtering by date range" do
+      [:start, :end].each do |date_kind|
+        describe "for #{date_kind} date" do
+          let(:start_date) { "2010-01-01" }
+          let(:end_date) { "2010-04-01" }
+          let(:date_field) { "#{date_kind}_date" }
+
+          around do |example|
+            Timecop.freeze(Time.zone.parse(start_date)) do
+              example.run
+            end
+          end
+
+          it "should use the default if not given the parameter" do
+            browse = Event::Browse.new(date: {})
+            expect(browse.send(date_field)).to eq send(date_field)
+            expect(browse.errors).to be_empty
+          end
+
+          it "should use the default if given a malformed parameter" do
+            browse = Event::Browse.new(date: "omgkittens")
+            expect(browse.send(date_field)).to eq send(date_field)
+            expect(browse.errors).to include(/invalid/)
+          end
+
+          it "should use the default if given a missing parameter" do
+            browse = Event::Browse.new(date: { foo: "bar" })
+            expect(browse.send(date_field)).to eq send(date_field)
+            expect(browse.errors).to include(/invalid/)
+          end
+
+          it "should use the default if given an empty parameter" do
+            browse = Event::Browse.new(date: { date_kind => "" })
+            expect(browse.send(date_field)).to eq send(date_field)
+            expect(browse.errors).to include(/invalid/)
+          end
+
+          it "should use the default if given an invalid parameter" do
+            browse = Event::Browse.new(date: { date_kind => "omgkittens" })
+            expect(browse.send(date_field)).to eq send(date_field)
+            expect(browse.errors).to include(/invalid/)
+          end
+
+          it "should use the value if valid" do
+            expected = Date.yesterday.to_s("%Y-%m-%d")
+            browse = Event::Browse.new(date: { date_kind => expected })
+            expect(browse.send(date_field)).to eq expected
+          end
+        end
       end
 
-      describe "before time" do
-        before do
-          @events = Event::Browse.new(time: { end: @given_end_time.strftime('%I:%M %p') }).events
+      it "should return matching events" do
+        # Given
+        matching = [
+          Event.create!(
+            :title => "matching1",
+            :start_time => Time.zone.parse("2010-01-16 00:00"),
+            :end_time => Time.zone.parse("2010-01-16 01:00")
+          ),
+          Event.create!(:title => "matching2",
+            :start_time => Time.zone.parse("2010-01-16 23:00"),
+            :end_time => Time.zone.parse("2010-01-17 00:00")
+          ),
+        ]
+
+        non_matching = [
+          Event.create!(
+            :title => "nonmatchingbefore",
+            :start_time => Time.zone.parse("2010-01-15 23:00"),
+            :end_time => Time.zone.parse("2010-01-15 23:59")
+          ),
+          Event.create!(
+            :title => "nonmatchingafter",
+            :start_time => Time.zone.parse("2010-01-17 00:01"),
+            :end_time => Time.zone.parse("2010-01-17 01:00")
+          ),
+        ]
+
+        # When
+        browse = Event::Browse.new(date: { start: "2010-01-16", end: "2010-01-16" })
+        results = browse.events
+
+        # Then
+        expect(results).to eq matching
+      end
+    end
+
+    describe "when filtering by time range" do
+      let(:start_time) { "12:00 pm" }
+      let(:end_time) { "05:00 pm" }
+
+      let!(:before) do
+        FactoryGirl.create(:event,
+                           title: "before",
+                           start_time: Time.zone.parse("10:00"),
+                           end_time: Time.zone.parse("14:00"))
+      end
+
+      let!(:after) do
+        FactoryGirl.create(:event,
+                           title: "after",
+                           start_time: Time.zone.parse("14:00"),
+                           end_time: Time.zone.parse("18:00"))
+      end
+
+      let!(:within) do
+        FactoryGirl.create(:event,
+                           title: "within",
+                           start_time: Time.zone.parse("13:00"),
+                           end_time: Time.zone.parse("14:00"))
+      end
+
+      context "before time" do
+        subject do
+          Event::Browse.new(time: { end: end_time })
         end
 
-        it "should include events with end_time before given end time" do
-          expect(@events).to include(@event_before_end_time, @event_in_range)
-        end
-
-        it "should not include events with end_time after given end time" do
-          expect(@events).not_to include(@event_after_start_time)
+        it "should return events with end_time before given end time" do
+          expect(subject.events).to contain_exactly(before, within)
         end
       end
 
-      describe "after time" do
-        before do
-          @events = Event::Browse.new(time: { start: @given_start_time.strftime('%I:%M %p') }).events
+      context "after time" do
+        subject do
+          Event::Browse.new(time: { start: start_time })
         end
 
         it "should include events with start_time after given start time" do
-          expect(@events).to include(@event_after_start_time, @event_in_range)
-        end
-
-        it "should not include events with start_time before given start time" do
-          expect(@events).not_to include(@event_before_end_time)
+          expect(subject.events).to contain_exactly(after, within)
         end
       end
 
-      describe "within time range" do
-        before do
-          @events = Event::Browse.new(time: {
-            start: @given_start_time.strftime('%I:%M %p'),
-            end: @given_end_time.strftime('%I:%M %p'),
-          }).events
+      context "within time range" do
+        subject do
+          Event::Browse.new(time: { start: start_time, end: end_time })
         end
 
         it "should include events with start_time and end_time between given times" do
-          expect(@events).to include(@event_in_range)
+          expect(subject.events).to contain_exactly(within)
         end
+      end
+    end
 
-        it "should not include events with start_time and end_time not between given times" do
-          expect(@events).not_to include(@event_before_end_time)
-        end
+    describe "when ordering" do
+      it "defaults to order by start time" do
+        event1 = FactoryGirl.create(:event, start_time: Time.zone.parse("3003-01-01"))
+        event2 = FactoryGirl.create(:event, start_time: Time.zone.parse("3002-01-01"))
+        event3 = FactoryGirl.create(:event, start_time: Time.zone.parse("3001-01-01"))
+
+        browse = Event::Browse.new
+        expect(browse.events).to eq([event3, event2, event1])
+      end
+
+      it "can order by event name" do
+        event1 = FactoryGirl.create(:event, title: "CU there")
+        event2 = FactoryGirl.create(:event, title: "Be there")
+        event3 = FactoryGirl.create(:event, title: "An event")
+
+        browse = Event::Browse.new(order: "name")
+        expect(browse.events).to eq([event3, event2, event1])
+      end
+
+      it "can order by venue name" do
+        event1 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "C venue"))
+        event2 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "B venue"))
+        event3 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "A venue"))
+
+        browse = Event::Browse.new(order: "venue")
+        expect(browse.events).to eq([event3, event2, event1])
+      end
+    end
+
+    describe "#default?" do
+      it "is true when no params are supplied" do
+        subject = Event::Browse.new
+        expect(subject.default?).to be_truthy
+      end
+
+      it "is false when any params are supplied" do
+        subject = Event::Browse.new(order: "title")
+        expect(subject.default?).to be_falsey
       end
     end
   end

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -516,61 +516,6 @@ describe Event, :type => :model do
     end
   end
 
-  describe "when finding by time" do
-    before do
-      @given_start_time = Time.zone.parse("12:00")
-      @given_end_time = @given_start_time + 5.hours
-      @event_before_end_time = FactoryGirl.create(:event, start_time: Time.zone.parse("10:00"),
-                                                  end_time: Time.zone.parse("14:00"))
-      @event_after_start_time = FactoryGirl.create(:event, start_time: Time.zone.parse("14:00"),
-                                                  end_time: Time.zone.parse("18:00"))
-      @event_in_range = FactoryGirl.create(:event, start_time: Time.zone.parse("13:00"),
-                                                  end_time: Time.zone.parse("14:00"))
-    end
-
-    describe "before time" do
-      before do
-        @events = Event.before_time(@given_end_time.hour)
-      end
-
-      it "should include events with end_time before given end time" do
-        expect(@events).to include(@event_before_end_time,@event_in_range)
-      end
-
-      it "should not include events with end_time after given end time" do
-        expect(@events).not_to include(@event_after_start_time)
-      end
-    end
-
-    describe "after time" do
-      before do
-        @events = Event.after_time(@given_start_time.hour)
-      end
-
-      it "should include events with start_time after given start time" do
-        expect(@events).to include(@event_after_start_time,@event_in_range)
-      end
-
-      it "should not include events with start_time before given start time" do
-        expect(@events).not_to include(@event_before_end_time)
-      end
-    end
-
-    describe "within time range" do
-      before do
-        @events = Event.within_times(@given_start_time.hour, @given_end_time.hour)
-      end
-
-      it "should include events with start_time and end_time between given times" do
-        expect(@events).to include(@event_in_range)
-      end
-
-      it "should not include events with start_time and end_time not between given times" do
-        expect(@events).not_to include(@event_before_end_time)
-      end
-    end
-  end
-
   describe "when ordering" do
     describe "with .ordered_by_ui_field" do
       it "defaults to order by start time" do


### PR DESCRIPTION
`EventController#index` was getting a bit fat with non-controllery logic, so I extracted it into Event::Browse. Once done, this became a natural home for bits from both the `Event` model and the view template, so those got slimmed down further. Complexity is reduced, cohesion is increased, and the interface between controller and view is narrowed for less coupling. Win win win.

There is still more to do here... it'd be nice to replace `form_tag` with `form_for`, and filtering by time range ignores minutes and should be pushed down to SQL, but this is a cohesive step forward.