### PR TITLE
Refactor machine tag handling

### DIFF
--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -9,11 +9,11 @@ module TagsHelper
     internal_url = "/#{type.pluralize}/tag/#{tag.name}"
 
     link_classes = [link_class, "p-category"]
-    link_classes << "external #{tag.machine_tag[:namespace]} #{tag.machine_tag[:predicate]}" if tag.machine_tag[:url]
+    link_classes << "external #{tag.machine_tag.namespace} #{tag.machine_tag.predicate}" if tag.machine_tag.url
 
     link_text = [tag_icon(tag.name), escape_once(tag.name)].compact.join(' ').html_safe
 
-    link_to link_text, (tag.machine_tag[:url] || internal_url), :class => link_classes.compact.join(' ')
+    link_to link_text, (tag.machine_tag.url || internal_url), class: link_classes.compact.join(' ')
   end
   private :tag_link
 

--- a/app/models/calagator/source/parser.rb
+++ b/app/models/calagator/source/parser.rb
@@ -84,8 +84,7 @@ class Source::Parser < Struct.new(:opts)
       duplicates.first.progenitor
     else
       venue_machine_tag_name = venue.tag_list.find do |tag_name|
-        predicate = TagModelExtensions::MachineTag.new(tag_name).to_hash[:predicate]
-        ActsAsTaggableOn::Tag::VENUE_PREDICATES.include? predicate
+        TagModelExtensions::MachineTag.new(tag_name).venue?
       end
       matched_venue = Venue.tagged_with(venue_machine_tag_name).first
 

--- a/app/models/calagator/source/parser.rb
+++ b/app/models/calagator/source/parser.rb
@@ -84,7 +84,7 @@ class Source::Parser < Struct.new(:opts)
       duplicates.first.progenitor
     else
       venue_machine_tag_name = venue.tag_list.find do |tag_name|
-        TagModelExtensions::MachineTag.new(tag_name).venue?
+        MachineTag.new(tag_name).venue?
       end
       matched_venue = Venue.tagged_with(venue_machine_tag_name).first
 

--- a/app/models/calagator/source/parser.rb
+++ b/app/models/calagator/source/parser.rb
@@ -83,10 +83,10 @@ class Source::Parser < Struct.new(:opts)
     if duplicates.present?
       duplicates.first.progenitor
     else
-      venue_machine_tag_name = venue.tag_list.find { |t|
-        # Match 2 in the MACHINE_TAG_PATTERN is the predicate
-        ActsAsTaggableOn::Tag::VENUE_PREDICATES.include? t.match(ActsAsTaggableOn::Tag::MACHINE_TAG_PATTERN)[2]
-      }
+      venue_machine_tag_name = venue.tag_list.find do |tag_name|
+        predicate = TagModelExtensions::MachineTag.new(tag_name).to_hash[:predicate]
+        ActsAsTaggableOn::Tag::VENUE_PREDICATES.include? predicate
+      end
       matched_venue = Venue.tagged_with(venue_machine_tag_name).first
 
       if matched_venue.present?

--- a/config/initializers/load_tag_model_extensions.rb
+++ b/config/initializers/load_tag_model_extensions.rb
@@ -1,3 +1,0 @@
-require "acts-as-taggable-on"
-require "calagator/tag_model_extensions"
-ActsAsTaggableOn::Tag.send :include, Calagator::TagModelExtensions

--- a/config/initializers/machine_tag_extensions.rb
+++ b/config/initializers/machine_tag_extensions.rb
@@ -4,46 +4,48 @@ ActsAsTaggableOn::Tag.send :include, Calagator::MachineTag::TagExtensions
 
 # Structure of machine tag namespaces and predicates to their URLs. See
 # Calagator::MachineTag for details.
-Calagator::MachineTag.urls.merge! \
-  'epdx' => {
-    'company' => 'http://epdx.org/companies/%s',
-    'group' => 'http://epdx.org/groups/%s',
-    'person' => 'http://epdx.org/people/%s',
-    'project' => 'http://epdx.org/projects/%s',
-  },
-  'upcoming' => {
-    'event' => "http://upcoming.yahoo.com/event/%s",
-    'venue' => "http://upcoming.yahoo.com/venue/%s"
-  },
-    'plancast' => {
-    'activity' => "http://plancast.com/a/%s",
-    'plan' => "http://plancast.com/p/%s"
-  },
-    'yelp' => {
-    'biz' => "http://www.yelp.com/biz/%s"
-  },
-    'foursquare' => {
-    'venue' => "http://foursquare.com/venue/%s"
-  },
-    'gowalla' => {
-    'spot' => "http://gowalla.com/spots/%s"
-  },
-    'shizzow' => {
-    'place' => "http://www.shizzow.com/places/%s"
-  },
-    'meetup' => {
-    'group' => "http://www.meetup.com/%s"
-  },
-    'facebook' => {
-    'event' => "http://www.facebook.com/event.php?eid=%s"
-  },
-    'lanyrd' => {
-    'event' => "http://lanyrd.com/%s"
-  }
+Calagator::MachineTag.configure do |config|
+  config.urls.merge! \
+    'epdx' => {
+      'company' => 'http://epdx.org/companies/%s',
+      'group' => 'http://epdx.org/groups/%s',
+      'person' => 'http://epdx.org/people/%s',
+      'project' => 'http://epdx.org/projects/%s',
+    },
+    'upcoming' => {
+      'event' => "http://upcoming.yahoo.com/event/%s",
+      'venue' => "http://upcoming.yahoo.com/venue/%s"
+    },
+      'plancast' => {
+      'activity' => "http://plancast.com/a/%s",
+      'plan' => "http://plancast.com/p/%s"
+    },
+      'yelp' => {
+      'biz' => "http://www.yelp.com/biz/%s"
+    },
+      'foursquare' => {
+      'venue' => "http://foursquare.com/venue/%s"
+    },
+      'gowalla' => {
+      'spot' => "http://gowalla.com/spots/%s"
+    },
+      'shizzow' => {
+      'place' => "http://www.shizzow.com/places/%s"
+    },
+      'meetup' => {
+      'group' => "http://www.meetup.com/%s"
+    },
+      'facebook' => {
+      'event' => "http://www.facebook.com/event.php?eid=%s"
+    },
+      'lanyrd' => {
+      'event' => "http://lanyrd.com/%s"
+    }
 
-Calagator::MachineTag.venue_predicates = %w(venue place spot biz)
+  config.venue_predicates = %w(venue place spot biz)
 
-Calagator::MachineTag.defunct_namespaces = %w(upcoming gowalla shizzow)
+  config.defunct_namespaces = %w(upcoming gowalla shizzow)
 
-Calagator::MachineTag.site_root_url = Calagator.url
+  config.site_root_url = Calagator.url
+end
 

--- a/config/initializers/machine_tag_extensions.rb
+++ b/config/initializers/machine_tag_extensions.rb
@@ -45,3 +45,5 @@ Calagator::MachineTag.venue_predicates = %w(venue place spot biz)
 
 Calagator::MachineTag.defunct_namespaces = %w(upcoming gowalla shizzow)
 
+Calagator::MachineTag.site_root_url = Calagator.url
+

--- a/config/initializers/machine_tag_extensions.rb
+++ b/config/initializers/machine_tag_extensions.rb
@@ -1,0 +1,3 @@
+require "acts-as-taggable-on"
+require "calagator/machine_tag"
+ActsAsTaggableOn::Tag.send :include, Calagator::MachineTag::TagExtensions

--- a/config/initializers/machine_tag_extensions.rb
+++ b/config/initializers/machine_tag_extensions.rb
@@ -1,3 +1,47 @@
 require "acts-as-taggable-on"
 require "calagator/machine_tag"
 ActsAsTaggableOn::Tag.send :include, Calagator::MachineTag::TagExtensions
+
+# Structure of machine tag namespaces and predicates to their URLs. See
+# Calagator::MachineTag for details.
+Calagator::MachineTag.urls.merge! \
+  'epdx' => {
+    'company' => 'http://epdx.org/companies/%s',
+    'group' => 'http://epdx.org/groups/%s',
+    'person' => 'http://epdx.org/people/%s',
+    'project' => 'http://epdx.org/projects/%s',
+  },
+  'upcoming' => {
+    'event' => "http://upcoming.yahoo.com/event/%s",
+    'venue' => "http://upcoming.yahoo.com/venue/%s"
+  },
+    'plancast' => {
+    'activity' => "http://plancast.com/a/%s",
+    'plan' => "http://plancast.com/p/%s"
+  },
+    'yelp' => {
+    'biz' => "http://www.yelp.com/biz/%s"
+  },
+    'foursquare' => {
+    'venue' => "http://foursquare.com/venue/%s"
+  },
+    'gowalla' => {
+    'spot' => "http://gowalla.com/spots/%s"
+  },
+    'shizzow' => {
+    'place' => "http://www.shizzow.com/places/%s"
+  },
+    'meetup' => {
+    'group' => "http://www.meetup.com/%s"
+  },
+    'facebook' => {
+    'event' => "http://www.facebook.com/event.php?eid=%s"
+  },
+    'lanyrd' => {
+    'event' => "http://lanyrd.com/%s"
+  }
+
+Calagator::MachineTag.venue_predicates = %w(venue place spot biz)
+
+Calagator::MachineTag.defunct_namespaces = %w(upcoming gowalla shizzow)
+

--- a/lib/calagator/machine_tag.rb
+++ b/lib/calagator/machine_tag.rb
@@ -11,6 +11,7 @@ class MachineTag < Struct.new(:name)
   cattr_accessor(:urls) { Hash.new }
   cattr_accessor(:venue_predicates) { Array.new }
   cattr_accessor(:defunct_namespaces) { Array.new }
+  cattr_accessor(:site_root_url) { "http://example.com/" }
 
   # Return a machine tag hash for this tag, or an empty hash if this isn't a
   # machine tag. The hash will always contain :namespace, :predicate and :value
@@ -84,10 +85,6 @@ class MachineTag < Struct.new(:name)
 
   def event_date
     Event.tagged_with(name).limit(1).pluck(:start_time).first
-  end
-
-  def site_root_url
-    Calagator.url
   end
 end
 

--- a/lib/calagator/machine_tag.rb
+++ b/lib/calagator/machine_tag.rb
@@ -8,53 +8,9 @@ class MachineTag < Struct.new(:name)
     end
   end
 
-  # Structure of machine tag namespaces and predicates to their URLs. See
-  # #machine_tag for details.
-  MACHINE_TAG_URLS = {
-    'epdx' => {
-      'company' => 'http://epdx.org/companies/%s',
-      'group' => 'http://epdx.org/groups/%s',
-      'person' => 'http://epdx.org/people/%s',
-      'project' => 'http://epdx.org/projects/%s',
-    },
-    'upcoming' => {
-      'event' => "http://upcoming.yahoo.com/event/%s",
-      'venue' => "http://upcoming.yahoo.com/venue/%s"
-    },
-      'plancast' => {
-      'activity' => "http://plancast.com/a/%s",
-      'plan' => "http://plancast.com/p/%s"
-    },
-      'yelp' => {
-      'biz' => "http://www.yelp.com/biz/%s"
-    },
-      'foursquare' => {
-      'venue' => "http://foursquare.com/venue/%s"
-    },
-      'gowalla' => {
-      'spot' => "http://gowalla.com/spots/%s"
-    },
-      'shizzow' => {
-      'place' => "http://www.shizzow.com/places/%s"
-    },
-      'meetup' => {
-      'group' => "http://www.meetup.com/%s"
-    },
-      'facebook' => {
-      'event' => "http://www.facebook.com/event.php?eid=%s"
-    },
-      'lanyrd' => {
-      'event' => "http://lanyrd.com/%s"
-    }
-  } unless defined?(MACHINE_TAG_URLS)
-
-  # Regular expression for parsing machine tags
-  MACHINE_TAG_PATTERN = /(?<namespace>[^:]+):(?<predicate>[^=]+)=(?<value>.+)/ unless defined?(MACHINE_TAG_PATTERN)
-
-  # Machine tag predicates that refer to place entries
-  VENUE_PREDICATES = %w(venue place spot biz) unless defined?(VENUE_PREDICATES)
-
-  DEFUNCT_NAMESPACES = %w(upcoming gowalla shizzow)
+  cattr_accessor(:urls) { Hash.new }
+  cattr_accessor(:venue_predicates) { Array.new }
+  cattr_accessor(:defunct_namespaces) { Array.new }
 
   # Return a machine tag hash for this tag, or an empty hash if this isn't a
   # machine tag. The hash will always contain :namespace, :predicate and :value
@@ -82,10 +38,13 @@ class MachineTag < Struct.new(:name)
   end
 
   def venue?
-    VENUE_PREDICATES.include? predicate
+    venue_predicates.include? predicate
   end
 
   private
+
+  # Regular expression for parsing machine tags
+  MACHINE_TAG_PATTERN = /(?<namespace>[^:]+):(?<predicate>[^=]+)=(?<value>.+)/
 
   def matches
     name.match(MACHINE_TAG_PATTERN)
@@ -104,7 +63,7 @@ class MachineTag < Struct.new(:name)
   end
 
   def url
-    return unless machine_tag = MACHINE_TAG_URLS[namespace]
+    return unless machine_tag = urls[namespace]
     return unless url_template = machine_tag[predicate]
     url = sprintf(url_template, value)
     url = "#{site_root_url}defunct?url=https://web.archive.org/web/#{archive_date}/#{url}" if defunct?
@@ -112,7 +71,7 @@ class MachineTag < Struct.new(:name)
   end
 
   def defunct?
-    DEFUNCT_NAMESPACES.include? namespace
+    defunct_namespaces.include? namespace
   end
 
   def archive_date

--- a/lib/calagator/machine_tag.rb
+++ b/lib/calagator/machine_tag.rb
@@ -54,6 +54,8 @@ class MachineTag < Struct.new(:name)
   # Machine tag predicates that refer to place entries
   VENUE_PREDICATES = %w(venue place spot biz) unless defined?(VENUE_PREDICATES)
 
+  DEFUNCT_NAMESPACES = %w(upcoming gowalla shizzow)
+
   # Return a machine tag hash for this tag, or an empty hash if this isn't a
   # machine tag. The hash will always contain :namespace, :predicate and :value
   # key-value pairs. It may also contain an :url if one is known.
@@ -110,7 +112,7 @@ class MachineTag < Struct.new(:name)
   end
 
   def defunct?
-    %w(upcoming gowalla shizzow).include? namespace
+    DEFUNCT_NAMESPACES.include? namespace
   end
 
   def archive_date

--- a/lib/calagator/machine_tag.rb
+++ b/lib/calagator/machine_tag.rb
@@ -8,6 +8,10 @@ class MachineTag < Struct.new(:name)
     end
   end
 
+  def self.configure
+    yield self
+  end
+
   cattr_accessor(:urls) { Hash.new }
   cattr_accessor(:venue_predicates) { Array.new }
   cattr_accessor(:defunct_namespaces) { Array.new }

--- a/lib/calagator/tag_model_extensions.rb
+++ b/lib/calagator/tag_model_extensions.rb
@@ -95,7 +95,7 @@ module TagModelExtensions
     return unless machine_tag = MACHINE_TAG_URLS[namespace]
     return unless url_template = machine_tag[predicate]
     url = sprintf(url_template, value)
-    url = "#{domain}/defunct?url=https://web.archive.org/web/#{archive_date}/#{url}" if defunct?
+    url = "#{site_root_url}defunct?url=https://web.archive.org/web/#{archive_date}/#{url}" if defunct?
     url
   end
 
@@ -115,8 +115,8 @@ module TagModelExtensions
     Event.tagged_with(self).limit(1).pluck(:start_time).first
   end
 
-  def domain
-    Rails.env.production? ? "http://calagator.org" : "http://localhost:3000"
+  def site_root_url
+    Calagator.url
   end
 end
 

--- a/lib/calagator/tag_model_extensions.rb
+++ b/lib/calagator/tag_model_extensions.rb
@@ -78,6 +78,10 @@ module TagModelExtensions
       }
     end
 
+    def venue?
+      VENUE_PREDICATES.include? predicate
+    end
+
     private
 
     def matches

--- a/lib/calagator/tag_model_extensions.rb
+++ b/lib/calagator/tag_model_extensions.rb
@@ -43,7 +43,7 @@ module TagModelExtensions
   } unless defined?(MACHINE_TAG_URLS)
 
   # Regular expression for parsing machine tags
-  MACHINE_TAG_PATTERN = /([^:]+):([^=]+)=(.+)/ unless defined?(MACHINE_TAG_PATTERN)
+  MACHINE_TAG_PATTERN = /(?<namespace>[^:]+):(?<predicate>[^=]+)=(?<value>.+)/ unless defined?(MACHINE_TAG_PATTERN)
 
   # Machine tag predicates that refer to place entries
   VENUE_PREDICATES = %w(venue place spot biz) unless defined?(VENUE_PREDICATES)
@@ -64,7 +64,7 @@ module TagModelExtensions
   #     :value     => "1234",
   #     :url       => "http://www.meetup.com/1234",
   def machine_tag
-    return {} unless matches?
+    return {} unless matches
     {
       namespace: namespace,
       predicate: predicate,
@@ -75,26 +75,20 @@ module TagModelExtensions
 
   private
 
-  def matches?
-    name =~ MACHINE_TAG_PATTERN
+  def matches
+    name.match(MACHINE_TAG_PATTERN)
   end
 
   def namespace
-    components = name.match(MACHINE_TAG_PATTERN)
-    namespace, predicate, value = components.captures
-    namespace
+    matches[:namespace]
   end
 
   def predicate
-    components = name.match(MACHINE_TAG_PATTERN)
-    namespace, predicate, value = components.captures
-    predicate
+    matches[:predicate]
   end
 
   def value
-    components = name.match(MACHINE_TAG_PATTERN)
-    namespace, predicate, value = components.captures
-    value
+    matches[:value]
   end
 
   def url

--- a/lib/calagator/tag_model_extensions.rb
+++ b/lib/calagator/tag_model_extensions.rb
@@ -104,21 +104,19 @@ module TagModelExtensions
   end
 
   def archive_date
-    return event.start_time.strftime("%Y%m%d") if event
-    return venue.created_at.strftime("%Y%m%d") if venue
+    (venue_date || event_date).strftime("%Y%m%d")
   end
 
-  def event
-    Event.tagged_with(self).first
+  def venue_date
+    Venue.tagged_with(self).limit(1).pluck(:created_at).first
   end
 
-  def venue
-    Venue.tagged_with(self).first
+  def event_date
+    Event.tagged_with(self).limit(1).pluck(:start_time).first
   end
 
   def domain
-    return "http://localhost:3000" if Rails.env.development? || Rails.env.test?
-    return "http://calagator.org" if Rails.env.production?
+    Rails.env.production? ? "http://calagator.org" : "http://localhost:3000"
   end
 end
 

--- a/lib/calagator/tag_model_extensions.rb
+++ b/lib/calagator/tag_model_extensions.rb
@@ -2,14 +2,6 @@
 module Calagator
 
 module TagModelExtensions
-  def self.included(base)
-    base.class_eval do
-      scope :machine_tags, -> { where("name LIKE '%:%=%'") }
-    end
-  end
-
-  #---[ Machine tags ]----------------------------------------------------
-
   # Structure of machine tag namespaces and predicates to their URLs. See
   # #machine_tag for details.
   MACHINE_TAG_URLS = {

--- a/lib/calagator/tag_model_extensions.rb
+++ b/lib/calagator/tag_model_extensions.rb
@@ -92,16 +92,15 @@ module TagModelExtensions
   end
 
   def url
-    url = nil
-    if machine_tag = MACHINE_TAG_URLS[namespace]
-      if url_template = machine_tag[predicate]
-        url = sprintf(url_template, value)
-        if namespace =~ /\A(upcoming|gowalla|shizzow)\Z/
-          url = "#{domain}/defunct?url=https://web.archive.org/web/#{archive_date}/#{url}"
-        end
-      end
-    end
+    return unless machine_tag = MACHINE_TAG_URLS[namespace]
+    return unless url_template = machine_tag[predicate]
+    url = sprintf(url_template, value)
+    url = "#{domain}/defunct?url=https://web.archive.org/web/#{archive_date}/#{url}" if defunct?
     url
+  end
+
+  def defunct?
+    %w(upcoming gowalla shizzow).include? namespace
   end
 
   def archive_date

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -20,7 +20,7 @@ describe ActsAsTaggableOn::Tag, :type => :model do
       expect(@valid_machine_tag.machine_tag[:url]).to eq "http://www.meetup.com/1234"
     end
 
-    it "should redirect to 'defunct' page with archive url as query param" do
+    it "should redirect to 'defunct' page with archive url as query param when using a defunct provider" do
       @event = FactoryGirl.create :event, tag_list: 'upcoming:event=1234'
       event_date = @event.start_time.strftime("%Y%m%d")
       expect(@event.tags.last.machine_tag[:url]).to eq "http://localhost:3000/defunct?url=https://web.archive.org/web/#{event_date}/http://upcoming.yahoo.com/event/1234"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -2,34 +2,45 @@ require 'spec_helper'
 
 describe ActsAsTaggableOn::Tag, :type => :model do
   describe "handling machine tags" do
-    before do
-      @valid_machine_tag = ActsAsTaggableOn::Tag.new(:name => 'meetup:group=1234')
+    context "when valid" do
+      subject do
+        ActsAsTaggableOn::Tag.new(name: 'meetup:group=1234')
+      end
+
+      it "should parse a machine tag into components" do
+        expect(subject.machine_tag.namespace).to eq 'meetup'
+        expect(subject.machine_tag.predicate).to eq 'group'
+        expect(subject.machine_tag.value).to eq '1234'
+      end
+
+      it "should generate a url for supported namespaces/predicates" do
+        expect(subject.machine_tag.url).to eq "http://www.meetup.com/1234"
+      end
+
+      it "should redirect to 'defunct' page with archive url as query param when using a defunct provider" do
+        @event = FactoryGirl.create :event, tag_list: 'upcoming:event=1234'
+        event_date = @event.start_time.strftime("%Y%m%d")
+        expect(@event.tags.last.machine_tag.url).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{event_date}/http://upcoming.yahoo.com/event/1234"
+      end
+
+      it "should redirect correctly for venue tags also" do
+        @venue = FactoryGirl.create :venue, tag_list: 'upcoming:venue=1234'
+        venue_date = @venue.created_at.strftime("%Y%m%d")
+        expect(@venue.tags.last.machine_tag.url).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{venue_date}/http://upcoming.yahoo.com/venue/1234"
+      end
     end
 
-    it "should return an empty hash when the tag is not a machine tag" do
-      expect(ActsAsTaggableOn::Tag.new(:name => 'not a machine tag').machine_tag).to eq({})
-    end
+    context "when invalid" do
+      subject do
+        ActsAsTaggableOn::Tag.new(name: 'not a machine tag')
+      end
 
-    it "should parse a machine tag into components" do
-      expect(@valid_machine_tag.machine_tag[:namespace]).to eq 'meetup'
-      expect(@valid_machine_tag.machine_tag[:predicate]).to eq 'group'
-      expect(@valid_machine_tag.machine_tag[:value]).to eq '1234'
-    end
-
-    it "should generate a url for supported namespaces/predicates" do
-      expect(@valid_machine_tag.machine_tag[:url]).to eq "http://www.meetup.com/1234"
-    end
-
-    it "should redirect to 'defunct' page with archive url as query param when using a defunct provider" do
-      @event = FactoryGirl.create :event, tag_list: 'upcoming:event=1234'
-      event_date = @event.start_time.strftime("%Y%m%d")
-      expect(@event.tags.last.machine_tag[:url]).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{event_date}/http://upcoming.yahoo.com/event/1234"
-    end
-
-    it "should redirect correctly for venue tags also" do
-      @venue = FactoryGirl.create :venue, tag_list: 'upcoming:venue=1234'
-      venue_date = @venue.created_at.strftime("%Y%m%d")
-      expect(@venue.tags.last.machine_tag[:url]).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{venue_date}/http://upcoming.yahoo.com/venue/1234"
+      it "should have empty properties when the tag is not a machine tag" do
+        expect(subject.machine_tag.url).to be_nil
+        expect(subject.machine_tag.namespace).to be_nil
+        expect(subject.machine_tag.predicate).to be_nil
+        expect(subject.machine_tag.value).to be_nil
+      end
     end
   end
 end

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -30,6 +30,18 @@ describe ActsAsTaggableOn::Tag, :type => :model do
       end
     end
 
+    describe "#venue?" do
+      it "knows when its a venue" do
+        subject = ActsAsTaggableOn::Tag.new(name: 'upcoming:venue=1234')
+        expect(subject.machine_tag.venue?).to be_truthy
+      end
+
+      it "knows when its not a venue" do
+        subject = ActsAsTaggableOn::Tag.new(name: 'meetup:group=1234')
+        expect(subject.machine_tag.venue?).to be_falsy
+      end
+    end
+
     context "when invalid" do
       subject do
         ActsAsTaggableOn::Tag.new(name: 'not a machine tag')

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -23,13 +23,13 @@ describe ActsAsTaggableOn::Tag, :type => :model do
     it "should redirect to 'defunct' page with archive url as query param when using a defunct provider" do
       @event = FactoryGirl.create :event, tag_list: 'upcoming:event=1234'
       event_date = @event.start_time.strftime("%Y%m%d")
-      expect(@event.tags.last.machine_tag[:url]).to eq "http://localhost:3000/defunct?url=https://web.archive.org/web/#{event_date}/http://upcoming.yahoo.com/event/1234"
+      expect(@event.tags.last.machine_tag[:url]).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{event_date}/http://upcoming.yahoo.com/event/1234"
     end
 
     it "should redirect correctly for venue tags also" do
       @venue = FactoryGirl.create :venue, tag_list: 'upcoming:venue=1234'
       venue_date = @venue.created_at.strftime("%Y%m%d")
-      expect(@venue.tags.last.machine_tag[:url]).to eq "http://localhost:3000/defunct?url=https://web.archive.org/web/#{venue_date}/http://upcoming.yahoo.com/venue/1234"
+      expect(@venue.tags.last.machine_tag[:url]).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{venue_date}/http://upcoming.yahoo.com/venue/1234"
     end
   end
 end


### PR DESCRIPTION
This refactors one of the last remaining bits of scary code.

* The `.machine_tags` method appears to be completely unused, so we can just delete it, which is my absolute favorite "refactoring" to do! Tests are still green, so its technically a refactoring, right?? :smile: 

* Break up complex `#machine_tag` method, and refactor into a composed method.