### PR TITLE
Refactor duplicate finding

### DIFF
--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -62,8 +62,7 @@ class Event < ActiveRecord::Base
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :venue_id
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
-  duplicate_finding_na_scope -> { future }
-  duplicate_finding_duplicate_scope -> { future }
+  duplicate_finding_scope -> { future }
 
   # Named scopes
   scope :after_date, lambda { |date|

--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -63,7 +63,7 @@ class Event < ActiveRecord::Base
   duplicate_checking_ignores_attributes    :source_id, :version, :venue_id
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
   duplicate_finding_na_scope -> { future }
-  duplicate_finding_duplicate_scope -> { ["a.start_time >= ?", 1.day.ago] }
+  duplicate_finding_duplicate_scope -> { future }
 
   # Named scopes
   scope :after_date, lambda { |date|
@@ -71,7 +71,7 @@ class Event < ActiveRecord::Base
   }
   scope :on_or_after_date, lambda { |date|
     time = date.beginning_of_day
-    where("(start_time >= :time) OR (end_time IS NOT NULL AND end_time > :time)",
+    where("(events.start_time >= :time) OR (events.end_time IS NOT NULL AND events.end_time > :time)",
       :time => time).order(:start_time)
   }
   scope :before_date, lambda { |date|

--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -62,7 +62,7 @@ class Event < ActiveRecord::Base
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :venue_id
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
-  duplicate_finding_scope -> { future }
+  duplicate_finding_scope -> { future.order(:id) }
 
   # Named scopes
   scope :after_date, lambda { |date|

--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -166,7 +166,6 @@ class Event < ActiveRecord::Base
     else
       kind = %w[all any].include?(type) ? type.to_sym : type.split(',').map(&:to_sym)
       find_duplicates_by(kind,
-        :grouped => true,
         :where => "a.start_time >= #{connection.quote(Time.now - 1.day)}")
     end
   end

--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -101,7 +101,6 @@ class Venue < ActiveRecord::Base
       kind = %w[all any].include?(type) ? type.to_sym : type.split(',').map(&:to_sym)
 
       return self.find_duplicates_by(kind, 
-        :grouped  => true, 
         :where    => 'a.duplicate_of_id IS NULL AND b.duplicate_of_id IS NULL'
       )
     end

--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -78,11 +78,10 @@ class Venue < ActiveRecord::Base
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :closed, :wifi, :access_notes
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
-  duplicate_finding_na_scope -> { where(duplicate_of_id: nil).order('LOWER(venues.title)') }
-  duplicate_finding_duplicate_scope -> { where(duplicate_of_id: nil).order('LOWER(venues.title)') }
+  duplicate_finding_scope -> { non_duplicates.order('LOWER(venues.title)') }
 
   # Named scopes
-  scope :masters,          -> { where(duplicate_of_id: nil).includes(:source, :events, :tags, :taggings) }
+  scope :masters,          -> { non_duplicates.includes(:source, :events, :tags, :taggings) }
   scope :with_public_wifi, -> { where(wifi: true) }
   scope :in_business,      -> { where(closed: false) }
   scope :out_of_business,  -> { where(closed: true) }

--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -78,33 +78,14 @@ class Venue < ActiveRecord::Base
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :closed, :wifi, :access_notes
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
+  duplicate_finding_na_scope -> { where(duplicate_of_id: nil).order('LOWER(venues.title)') }
+  duplicate_finding_duplicate_scope -> { "a.duplicate_of_id IS NULL AND b.duplicate_of_id IS NULL" }
 
   # Named scopes
   scope :masters,          -> { where(duplicate_of_id: nil).includes(:source, :events, :tags, :taggings) }
   scope :with_public_wifi, -> { where(wifi: true) }
   scope :in_business,      -> { where(closed: false) }
   scope :out_of_business,  -> { where(closed: true) }
-
-  #===[ Finders ]=========================================================
-
-  # Return Hash of Venues grouped by the +type+, e.g., a 'title'. Each Venue
-  # record will include an <tt>events_count</tt> field containing the number of
-  # events at the venue, which improves performance for displaying these.
-  def self.find_duplicates_by_type(type='na')
-    case type
-    when 'na', nil, ''
-      # The LEFT OUTER JOIN makes sure that venues without any events are also returned.
-      return { [] => \
-        self.where('venues.duplicate_of_id IS NULL').order('LOWER(venues.title)')
-      }
-    else
-      kind = %w[all any].include?(type) ? type.to_sym : type.split(',').map(&:to_sym)
-
-      return self.find_duplicates_by(kind, 
-        :where    => 'a.duplicate_of_id IS NULL AND b.duplicate_of_id IS NULL'
-      )
-    end
-  end
 
   #===[ Search ]==========================================================
 

--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -79,7 +79,7 @@ class Venue < ActiveRecord::Base
   duplicate_checking_ignores_attributes    :source_id, :version, :closed, :wifi, :access_notes
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
   duplicate_finding_na_scope -> { where(duplicate_of_id: nil).order('LOWER(venues.title)') }
-  duplicate_finding_duplicate_scope -> { "a.duplicate_of_id IS NULL AND b.duplicate_of_id IS NULL" }
+  duplicate_finding_duplicate_scope -> { where(duplicate_of_id: nil).order('LOWER(venues.title)') }
 
   # Named scopes
   scope :masters,          -> { where(duplicate_of_id: nil).includes(:source, :events, :tags, :taggings) }

--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -78,7 +78,7 @@ class Venue < ActiveRecord::Base
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :closed, :wifi, :access_notes
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
-  duplicate_finding_scope -> { non_duplicates.order('LOWER(venues.title)') }
+  duplicate_finding_scope -> { non_duplicates.order('LOWER(venues.title), venues.id') }
 
   # Named scopes
   scope :masters,          -> { non_duplicates.includes(:source, :events, :tags, :taggings) }

--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -78,7 +78,7 @@ class Venue < ActiveRecord::Base
   include DuplicateChecking
   duplicate_checking_ignores_attributes    :source_id, :version, :closed, :wifi, :access_notes
   duplicate_squashing_ignores_associations :tags, :base_tags, :taggings
-  duplicate_finding_scope -> { non_duplicates.order('LOWER(venues.title), venues.id') }
+  duplicate_finding_scope -> { non_duplicates.order(:title, :id) }
 
   # Named scopes
   scope :masters,          -> { non_duplicates.includes(:source, :events, :tags, :taggings) }

--- a/app/views/calagator/events/duplicates.html.erb
+++ b/app/views/calagator/events/duplicates.html.erb
@@ -22,7 +22,7 @@
       <li><%= link_to_unless_current "All Events", url_for(:action => 'duplicates', :type => 'na') %></li>
     </ul>
   </div>
-  <% unless @grouped_events.empty? %>
+  <% unless @grouped.empty? %>
     <%= form_tag :action => "squash_many_duplicates", :method => :post %>
       <div class="flash notice">
         Select only one set of master and duplicate events. If you select an unrelated event, it will be merged into the same single master record.
@@ -30,7 +30,7 @@
       <div class='list_items'>
         <%= hidden_field_tag(:type, @type) %>
         <table>
-          <% for value, group in @grouped_events %>
+          <% for value, group in @grouped %>
             <tr>
               <th>Master?</th><th>Duplicate?</th><th>Event<%= " (#{value})" unless value.blank? %></th>
             </tr>

--- a/app/views/calagator/venues/duplicates.html.erb
+++ b/app/views/calagator/venues/duplicates.html.erb
@@ -25,7 +25,7 @@
     </ul>
   </div>
 
-  <% unless @grouped_venues.empty? %>
+  <% unless @grouped.empty? %>
     <%= form_tag :action => "squash_many_duplicates", :method => :post %>
       <div class="flash notice">
         Select only one set of master and duplicate venues. If you select an unrelated venue, it will be merged into the same single master record.
@@ -33,7 +33,7 @@
       <div class='list_items'>
         <%= hidden_field_tag(:type, @type) %>
         <table>
-          <% for value, group in @grouped_venues %>
+          <% for value, group in @grouped %>
             <tr>
               <th>Master?</th><th>Duplicate?</th><th># of Events</th><th>Venue<%= " (#{value})" unless value.blank? %></th>
             </tr>

--- a/lib/calagator/duplicate_checking.rb
+++ b/lib/calagator/duplicate_checking.rb
@@ -114,7 +114,7 @@ module DuplicateChecking
     end
 
     # Return Hash of duplicate events grouped by the +type+.
-    def find_duplicates_by_type(type='na')
+    def find_duplicates_by_type(type)
       DuplicateFinder.new(self, type.split(",")).find do |scope|
         scope.instance_exec &duplicate_finding_scope
       end

--- a/lib/calagator/duplicate_checking.rb
+++ b/lib/calagator/duplicate_checking.rb
@@ -116,27 +116,15 @@ module DuplicateChecking
       self._duplicate_finding_duplicate_scope
     end
 
-    # Return Hash of Events grouped by the +type+.
+    # Return Hash of duplicate events grouped by the +type+.
     def find_duplicates_by_type(type='na')
       case type.to_s.strip
       when 'na', ''
         { [] => duplicate_finding_na_scope.call }
       else
-        kind = %w[all any].include?(type) ? type.to_sym : type.split(',').map(&:to_sym)
-        find_duplicates_by(kind, where: duplicate_finding_duplicate_scope.call)
+        fields = %w[all any].include?(type) ? type.to_sym : type.split(',').map(&:to_sym)
+        DuplicateFinder.new(self, fields, where: duplicate_finding_duplicate_scope.call).find
       end
-    end
-
-    # Return events with duplicate values for a given set of fields.
-    #
-    # Options:
-    # * :grouped => Return Hash of events grouped by commonality, rather than returning an Array. Defaults to false.
-    # * :where => String that specifies additional arguments to add to the WHERE clause.
-    # * :select => String that specified additional arguments to add to the SELECT clause.
-    # * :from => String that specifies additional arguments to add to the FROM clause
-    # * :joins => String that specifies additional argument to add to a JOINS clause.
-    def find_duplicates_by(fields, options={})
-      DuplicateFinder.new(self, fields, options).find
     end
 
     # Squash duplicates. Options accept ActiveRecord instances or IDs.

--- a/lib/calagator/duplicate_checking.rb
+++ b/lib/calagator/duplicate_checking.rb
@@ -115,12 +115,8 @@ module DuplicateChecking
 
     # Return Hash of duplicate events grouped by the +type+.
     def find_duplicates_by_type(type='na')
-      if type == "na" || type.blank?
-        { [] => duplicate_finding_scope.call }
-      else
-        DuplicateFinder.new(self, type.split(",")).find do |scope|
-          scope.instance_exec &duplicate_finding_scope
-        end
+      DuplicateFinder.new(self, type.split(",")).find do |scope|
+        scope.instance_exec &duplicate_finding_scope
       end
     end
 

--- a/lib/calagator/duplicate_checking.rb
+++ b/lib/calagator/duplicate_checking.rb
@@ -14,6 +14,12 @@
 #
 #     # Declare associations that should be ignored during duplicate squashing
 #     duplicate_squashing_ignores_associations :tags
+#
+#     # Declare an optional default scope to be used for find_duplicates_by_type("na")
+#     duplicate_finding_na_scope -> { active }
+#
+#     # Declare an optional default scope to be used for find_duplicates_by_type
+#     duplicate_finding_duplicate_scope -> { active }
 #   end
 #
 #   # Set duplicates on objects
@@ -121,7 +127,9 @@ module DuplicateChecking
       if type == "na" || type.blank?
         { [] => duplicate_finding_na_scope.call }
       else
-        DuplicateFinder.new(self, type.split(","), duplicate_finding_duplicate_scope.call).find
+        DuplicateFinder.new(self, type.split(",")).find do |scope|
+          scope.instance_exec &duplicate_finding_duplicate_scope
+        end
       end
     end
 

--- a/lib/calagator/duplicate_checking.rb
+++ b/lib/calagator/duplicate_checking.rb
@@ -118,12 +118,10 @@ module DuplicateChecking
 
     # Return Hash of duplicate events grouped by the +type+.
     def find_duplicates_by_type(type='na')
-      case type.to_s.strip
-      when 'na', ''
+      if type == "na" || type.blank?
         { [] => duplicate_finding_na_scope.call }
       else
-        fields = %w[all any].include?(type) ? type.to_sym : type.split(',').map(&:to_sym)
-        DuplicateFinder.new(self, fields, where: duplicate_finding_duplicate_scope.call).find
+        DuplicateFinder.new(self, type.split(","), duplicate_finding_duplicate_scope.call).find
       end
     end
 

--- a/lib/calagator/duplicate_checking/controller_actions.rb
+++ b/lib/calagator/duplicate_checking/controller_actions.rb
@@ -4,10 +4,10 @@ module DuplicateChecking
   module ControllerActions
     # GET /#{model_class}/duplicates
     def duplicates
-      @type = params[:type]
-      @grouped_venues = @grouped_events = model_class.find_duplicates_by_type(@type)
+      @type = params[:type] || "na"
+      @grouped = model_class.find_duplicates_by_type(@type)
     rescue ArgumentError => e
-      @grouped_venues = @grouped_events = {}
+      @grouped = {}
       flash[:failure] = e.to_s
     end
 

--- a/lib/calagator/duplicate_checking/duplicate_finder.rb
+++ b/lib/calagator/duplicate_checking/duplicate_finder.rb
@@ -4,13 +4,15 @@ module DuplicateChecking
   class DuplicateFinder < Struct.new(:model, :fields)
     def find
       scope = model.select("#{model.table_name}.*")
-      scope.from!("#{model.table_name}, #{model.table_name} b")
-      scope.where!("#{model.table_name}.id <> b.id")
-      scope.where!("#{model.table_name}.duplicate_of_id" => nil)
-      scope.where!(query)
-      scope.distinct!
-
       scope = yield(scope) if block_given?
+
+      unless fields.empty? || fields == [:na]
+        scope.from!("#{model.table_name}, #{model.table_name} b")
+        scope.where!("#{model.table_name}.id <> b.id")
+        scope.where!("#{model.table_name}.duplicate_of_id" => nil)
+        scope.where!(query)
+        scope.distinct!
+      end
 
       group_by_fields(scope.to_a)
     end

--- a/lib/calagator/duplicate_checking/duplicate_finder.rb
+++ b/lib/calagator/duplicate_checking/duplicate_finder.rb
@@ -14,7 +14,7 @@ module DuplicateChecking
       # SQL distinct is not enough to guarantee unique records in this query
       records = scope.to_a.uniq
 
-      records = group_by_fields(records) if grouped
+      records = group_by_fields(records)
       records
     end
 
@@ -32,14 +32,10 @@ module DuplicateChecking
       end
     end
 
-    def grouped
-      options[:grouped] || false
-    end
-
     def group_by_fields records
       # Group by the field values we're matching on; skip any values for which we only have one record
       records = records.group_by do |record|
-        fields.map do |field|
+        Array(fields).map do |field|
           record.read_attribute(field)
         end
       end

--- a/spec/controllers/calagator/events_controller_spec.rb
+++ b/spec/controllers/calagator/events_controller_spec.rb
@@ -593,13 +593,13 @@ describe EventsController, :type => :controller do
         get 'duplicates', :type => 'title'
 
         # Current duplicates
-        assigns[:grouped_events].select{|keys,values| keys.include?(current_master.title)}.tap do |events|
+        assigns[:grouped].select{|keys,values| keys.include?(current_master.title)}.tap do |events|
           expect(events).not_to be_empty
           expect(events.first.last.size).to eq 2
         end
 
         # Past duplicates
-        expect(assigns[:grouped_events].select{|keys,values| keys.include?(past_master.title)}).to be_empty
+        expect(assigns[:grouped].select{|keys,values| keys.include?(past_master.title)}).to be_empty
       end
 
       it "should redirect duplicate events to their master" do

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -143,42 +143,6 @@ describe Event, :type => :model do
     end
   end
 
-  describe "when finding duplicates by type" do
-    def assert_default_find_duplicates_by_type(type)
-      expect(Event).to receive(:future).and_return 42
-      expect(Event.find_duplicates_by_type(type)).to eq({ [] => 42 })
-    end
-
-    it "should find all future events if called with nil" do
-      assert_default_find_duplicates_by_type(nil)
-    end
-
-    it "should find all future events if called with empty string" do
-      assert_default_find_duplicates_by_type('')
-    end
-
-    it "should find all future events if called with 'na'" do
-      assert_default_find_duplicates_by_type('na')
-    end
-
-    def assert_specific_find_by_duplicates_by(type, queried)
-      expect(Event).to receive(:find_duplicates_by).with(queried, where: anything())
-      Event.find_duplicates_by_type(type)
-    end
-
-    it "should find events with all duplicate fields if called with 'all'" do
-      assert_specific_find_by_duplicates_by('all', :all)
-    end
-
-    it "should find events with any duplicate fields if called with 'any'" do
-      assert_specific_find_by_duplicates_by('any', :any)
-    end
-
-    it "should find events with duplicate titles if called with 'title'" do
-      assert_specific_find_by_duplicates_by('title', [:title])
-    end
-  end
-
   describe "when processing date" do
     before do
       @event = Event.new(:title => "MyEvent")

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -544,7 +544,7 @@ describe Event, :type => :model do
     it "should return future events when provided na" do
       future = Event.create!(title: subject.title, start_time: 1.day.from_now)
       events = Event.find_duplicates_by_type("na")
-      expect(events).to eq({ [] => [subject, future] })
+      expect(events).to eq({ [nil] => [subject, future] })
     end
 
     it "should find duplicate title by title" do

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -568,8 +568,19 @@ describe Event, :type => :model do
   end
 
   describe "with finding duplicates (integration test)" do
+    before do
+      # this event should always be omitted from the results
+      past = FactoryGirl.create(:event, start_time: 1.week.ago)
+    end
+
     subject do
       FactoryGirl.create(:event)
+    end
+
+    it "should return future events when provided na" do
+      future = Event.create!(title: subject.title, start_time: 1.day.from_now)
+      events = Event.find_duplicates_by_type("na")
+      expect(events).to eq({ [] => [subject, future] })
     end
 
     it "should find duplicate title by title" do

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -574,43 +574,43 @@ describe Event, :type => :model do
 
     it "should find duplicate title by title" do
       clone = Event.create!(title: subject.title, start_time: subject.start_time )
-      events = Event.find_duplicates_by(:title)
+      events = Event.find_duplicates_by_type("title")
       expect(events).to eq({ [subject.title] => [subject, clone] })
     end
 
     it "should find duplicate title by any" do
       clone = Event.create!(title: subject.title, start_time: subject.start_time + 1.minute)
-      events = Event.find_duplicates_by(:title)
+      events = Event.find_duplicates_by_type("title")
       expect(events).to eq({ [subject.title] => [subject, clone] })
     end
 
     it "should not find duplicate title by url" do
       clone = Event.create!(title: subject.title, start_time: subject.start_time)
-      events = Event.find_duplicates_by(:url)
+      events = Event.find_duplicates_by_type("url")
       expect(events).to be_empty
     end
 
     it "should find complete duplicates by all" do
       clone = Event.create!(subject.attributes.merge(id: nil))
-      events = Event.find_duplicates_by(:all)
+      events = Event.find_duplicates_by_type("all")
       expect(events).to eq({ [nil] => [subject, clone] })
     end
 
     it "should not find incomplete duplicates by all" do
       clone = Event.create!(subject.attributes.merge(title: "SpaceCube", start_time: subject.start_time, id: nil))
-      events = Event.find_duplicates_by(:all)
+      events = Event.find_duplicates_by_type("all")
       expect(events).to be_empty
     end
 
     it "should find duplicate for matching multiple fields" do
       clone = Event.create!(title: subject.title, start_time: subject.start_time)
-      events = Event.find_duplicates_by([:title, :start_time])
+      events = Event.find_duplicates_by_type("title,start_time")
       expect(events).to eq({ [subject.title, subject.start_time] => [subject, clone] })
     end
 
     it "should not find duplicates for mismatching multiple fields" do
       clone = Event.create!(title: "SpaceCube", start_time: subject.start_time)
-      events = Event.find_duplicates_by([:title, :start_time])
+      events = Event.find_duplicates_by_type("title,start_time")
       expect(events).to be_empty
     end
   end

--- a/spec/models/calagator/venue_spec.rb
+++ b/spec/models/calagator/venue_spec.rb
@@ -93,43 +93,43 @@ describe Venue, :type => :model do
 
     it "should not match totally different records" do
       FactoryGirl.create(:venue)
-      expect(Venue.find_duplicates_by(:title)).to be_empty
+      expect(Venue.find_duplicates_by_type("title")).to be_empty
     end
 
     it "should not match similar records when not searching by duplicated fields" do
       FactoryGirl.create :venue, title: @existing.title
-      expect(Venue.find_duplicates_by(:description)).to be_empty
+      expect(Venue.find_duplicates_by_type("description")).to be_empty
     end
 
     it "should match similar records when searching by duplicated fields" do
       FactoryGirl.create :venue, title: @existing.title
-      expect(Venue.find_duplicates_by(:title)).to be_present
+      expect(Venue.find_duplicates_by_type("title")).to be_present
     end
 
     it "should match similar records when searching by :any" do
       FactoryGirl.create :venue, title: @existing.title
-      expect(Venue.find_duplicates_by(:any)).to be_present
+      expect(Venue.find_duplicates_by_type("any")).to be_present
     end
 
     it "should not match similar records when searching by multiple fields where not all are duplicated" do
       FactoryGirl.create :venue, title: @existing.title
-      expect(Venue.find_duplicates_by([:title, :description])).to be_empty
+      expect(Venue.find_duplicates_by_type("title,description")).to be_empty
     end
 
     it "should match similar records when searching by multiple fields where all are duplicated" do
       FactoryGirl.create(:venue, :title => @existing.title, :description => @existing.description)
-      expect(Venue.find_duplicates_by([:title, :description])).to be_present
+      expect(Venue.find_duplicates_by_type("title,description")).to be_present
     end
 
     it "should not match dissimilar records when searching by :all" do
       FactoryGirl.create(:venue)
-      expect(Venue.find_duplicates_by(:all)).to be_empty
+      expect(Venue.find_duplicates_by_type("all")).to be_empty
     end
 
     it "should match similar records when searching by :all" do
       attributes = @existing.attributes.reject{ |k,v| k == 'id'}
       Venue.create!(attributes)
-      expect(Venue.find_duplicates_by(:all)).to be_present
+      expect(Venue.find_duplicates_by_type("all")).to be_present
     end
 
     it "should match non duplicate venues when searching by default" do

--- a/spec/models/calagator/venue_spec.rb
+++ b/spec/models/calagator/venue_spec.rb
@@ -133,9 +133,9 @@ describe Venue, :type => :model do
       expect(Venue.find_duplicates_by_type("all")).to eq({ [nil] => [subject, venue] })
     end
 
-    it "should match non duplicate venues when searching by default" do
+    it "should match non duplicate venues when searching by na" do
       venue = FactoryGirl.create(:venue, title: "Venue B")
-      expect(Venue.find_duplicates_by_type).to eq({ [nil] => [subject, venue] })
+      expect(Venue.find_duplicates_by_type("na")).to eq({ [nil] => [subject, venue] })
     end
   end
 

--- a/spec/models/calagator/venue_spec.rb
+++ b/spec/models/calagator/venue_spec.rb
@@ -87,7 +87,7 @@ describe Venue, :type => :model do
   end
 
   describe "when finding duplicates [integration test]" do
-    subject do
+    subject! do
       FactoryGirl.create(:venue, title: "Venue A")
     end
 
@@ -135,7 +135,7 @@ describe Venue, :type => :model do
 
     it "should match non duplicate venues when searching by default" do
       venue = FactoryGirl.create(:venue, title: "Venue B")
-      expect(Venue.find_duplicates_by_type).to eq({ [] => [subject, venue] })
+      expect(Venue.find_duplicates_by_type).to eq({ [nil] => [subject, venue] })
     end
   end
 


### PR DESCRIPTION
Turns out that `.finds_duplicate_by` was only being called by `.finds_duplicate_by_type`, and there was duplication between the latter method on `Venue` and `Event`. Merging the methods and pushing the duplication up into the shared `DuplicateChecking` module simplifies all the pieces of this puzzle. Case in point: we no longer have any F scores on Code Climate after this merge!