### PR TITLE
Lock paper_trail_manager to 0.5.x for now

### DIFF
--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "jquery-rails"
   s.add_dependency "jquery-ui-rails", "~> 5.0"
   s.add_dependency "font-awesome-rails", "~> 4.3"
-  s.add_dependency "paper_trail_manager", "~> 0.5"
+  s.add_dependency "paper_trail_manager", "~> 0.5.0"
   s.add_dependency "utf8-cleaner", "~> 0.0.6"
   # s.add_dependency "mofo", path: "vendor/gems/mofo-0.2.8" # vendored fork with hpricot dependency replaced with nokogiri
   s.add_dependency "sunspot_rails", "~> 2.1"


### PR DESCRIPTION
Calagator currently does not work with paper_trail_manager 0.6.0, so all unrelated PRs will fail until that is resolved. This PR locks it down to 0.5.x, in anticipation of a future PR that will add compatibility with 0.6.0.