### PR TITLE
Refactor TagsHelper

### DIFF
--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -2,32 +2,35 @@ module Calagator
 
 module TagsHelper
   def tag_links_for(model)
-    class_name = model.class.model_name.human.downcase.pluralize
     model.tags.sort_by(&:name).map do |tag|
-      TagLink.new(class_name, tag, self).render
+      TagLink.new(model.class.table_name, tag, self).render
     end.join(', ').html_safe
   end
 
   class TagLink < Struct.new(:class_name, :tag, :context)
     def render
-      context.link_to link_text, (tag.machine_tag.url || internal_url), class: link_classes.compact.join(' ')
+      context.link_to text, url, class: css_class
     end
 
     private
 
-    def link_text
+    def text
       icon = TagIcon.new(tag.name, context)
       [icon.exists? && icon.image_tag, context.escape_once(tag.name)].compact.join(' ').html_safe
     end
 
-    def internal_url
-      "/#{class_name}/tag/#{tag.name}"
+    def url
+      machine_tag.url || "/#{class_name}/tag/#{tag.name}"
     end
 
-    def link_classes
+    def css_class
       classes = ["p-category"]
-      classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
-      classes
+      classes += ["external", machine_tag.namespace, machine_tag.predicate] if machine_tag.url
+      classes.join(' ')
+    end
+
+    def machine_tag
+      tag.machine_tag
     end
   end
 

--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -14,7 +14,8 @@ module TagsHelper
     link_classes = [link_class, "p-category"]
     link_classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
 
-    link_text = [TagIcon.new(tag.name, self).image_tag, escape_once(tag.name)].compact.join(' ').html_safe
+    icon = TagIcon.new(tag.name, self)
+    link_text = [icon.exists? && icon.image_tag, escape_once(tag.name)].compact.join(' ').html_safe
 
     link_to link_text, (tag.machine_tag.url || internal_url), class: link_classes.compact.join(' ')
   end
@@ -22,15 +23,14 @@ module TagsHelper
 
   class TagIcon < Struct.new(:name, :context)
     def image_tag
-      return unless exists?
       context.image_tag(image_path, title: name)
     end
 
-    private
-
     def exists?
-      !!Rails.application.assets[image_path]
+      Rails.application.assets[image_path]
     end
+
+    private
 
     def image_path
       "tag_icons/#{name}.png"
@@ -38,17 +38,11 @@ module TagsHelper
   end
 
   def display_tag_icons(event)
-    get_tag_icon_links(event).join(' ').html_safe
-  end
-
-  def get_tag_icon_links(event)
     event.tag_list.map do |tag_name|
-      icon = TagIcon.new(tag_name, self).image_tag
-      link_to(icon, tag_events_path(tag_name)) if icon
-    end
+      icon = TagIcon.new(tag_name, self)
+      link_to(icon.image_tag, tag_events_path(tag_name)) if icon.exists?
+    end.join(' ').html_safe
   end
-  private :get_tag_icon_links
-
 end
 
 end

--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -34,6 +34,13 @@ module TagsHelper
     end
   end
 
+  def display_tag_icons(event)
+    event.tag_list.map do |tag_name|
+      icon = TagIcon.new(tag_name, self)
+      link_to(icon.image_tag, tag_events_path(tag_name)) if icon.exists?
+    end.join(' ').html_safe
+  end
+
   class TagIcon < Struct.new(:name, :context)
     def image_tag
       context.image_tag(image_path, title: name)
@@ -48,13 +55,6 @@ module TagsHelper
     def image_path
       "tag_icons/#{name}.png"
     end
-  end
-
-  def display_tag_icons(event)
-    event.tag_list.map do |tag_name|
-      icon = TagIcon.new(tag_name, self)
-      link_to(icon.image_tag, tag_events_path(tag_name)) if icon.exists?
-    end.join(' ').html_safe
   end
 end
 

--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -22,14 +22,19 @@ module TagsHelper
 
   def tag_icon(tag_name)
     return unless icon_exists_for?(tag_name)
-    image_tag(asset_path("tag_icons/#{tag_name}.png"), title: tag_name)
+    image_tag(asset_path(tag_icon_path(tag_name)), title: tag_name)
   end
   private :tag_icon
 
   def icon_exists_for?(tag_name)
-    !!Rails.application.assets["tag_icons/#{tag_name}.png"]
+    !!Rails.application.assets[tag_icon_path(tag_name)]
   end
   private :icon_exists_for?
+
+  def tag_icon_path(tag_name)
+    "tag_icons/#{tag_name}.png"
+  end
+  private :tag_icon_path
 
   def display_tag_icons(event)
     get_tag_icon_links(event).join(' ').html_safe

--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -2,14 +2,17 @@ module Calagator
 
 module TagsHelper
   def tag_links_for(model)
-    model.tags.sort_by(&:name).map{|tag| tag_link(model.class.model_name.human.downcase, tag)}.join(', ').html_safe
+    class_name = model.class.model_name.human.downcase.pluralize
+    model.tags.sort_by(&:name).map do |tag|
+      tag_link(class_name, tag)
+    end.join(', ').html_safe
   end
 
-  def tag_link(type, tag, link_class=nil)
-    internal_url = "/#{type.pluralize}/tag/#{tag.name}"
+  def tag_link(class_name, tag, link_class=nil)
+    internal_url = "/#{class_name}/tag/#{tag.name}"
 
     link_classes = [link_class, "p-category"]
-    link_classes << "external #{tag.machine_tag.namespace} #{tag.machine_tag.predicate}" if tag.machine_tag.url
+    link_classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
 
     link_text = [tag_icon(tag.name), escape_once(tag.name)].compact.join(' ').html_safe
 
@@ -17,14 +20,19 @@ module TagsHelper
   end
   private :tag_link
 
+  def tag_icon(tag_name)
+    return unless icon_exists_for?(tag_name)
+    image_tag(asset_path("tag_icons/#{tag_name}.png"), title: tag_name)
+  end
+  private :tag_icon
+
   def icon_exists_for?(tag_name)
     !!Rails.application.assets["tag_icons/#{tag_name}.png"]
   end
+  private :icon_exists_for?
 
-  def tag_icon(tag_name)
-    if icon_exists_for?(tag_name)
-      image_tag(asset_path("tag_icons/#{tag_name}.png"), title: tag_name)
-    end
+  def display_tag_icons(event)
+    get_tag_icon_links(event).join(' ').html_safe
   end
 
   def get_tag_icon_links(event)
@@ -33,10 +41,8 @@ module TagsHelper
       link_to(icon, tag_events_path(tag_name)) if icon
     end
   end
+  private :get_tag_icon_links
 
-  def display_tag_icons(event)
-    get_tag_icon_links(event).join(' ').html_safe
-  end
 end
 
 end

--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -4,22 +4,23 @@ module TagsHelper
   def tag_links_for(model)
     class_name = model.class.model_name.human.downcase.pluralize
     model.tags.sort_by(&:name).map do |tag|
-      tag_link(class_name, tag)
+      TagLink.new(class_name, tag, self).render
     end.join(', ').html_safe
   end
 
-  def tag_link(class_name, tag, link_class=nil)
-    internal_url = "/#{class_name}/tag/#{tag.name}"
+  class TagLink < Struct.new(:class_name, :tag, :context)
+    def render
+      internal_url = "/#{class_name}/tag/#{tag.name}"
 
-    link_classes = [link_class, "p-category"]
-    link_classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
+      link_classes = ["p-category"]
+      link_classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
 
-    icon = TagIcon.new(tag.name, self)
-    link_text = [icon.exists? && icon.image_tag, escape_once(tag.name)].compact.join(' ').html_safe
+      icon = TagIcon.new(tag.name, context)
+      link_text = [icon.exists? && icon.image_tag, context.escape_once(tag.name)].compact.join(' ').html_safe
 
-    link_to link_text, (tag.machine_tag.url || internal_url), class: link_classes.compact.join(' ')
+      context.link_to link_text, (tag.machine_tag.url || internal_url), class: link_classes.compact.join(' ')
+    end
   end
-  private :tag_link
 
   class TagIcon < Struct.new(:name, :context)
     def image_tag

--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -14,27 +14,28 @@ module TagsHelper
     link_classes = [link_class, "p-category"]
     link_classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
 
-    link_text = [tag_icon(tag.name), escape_once(tag.name)].compact.join(' ').html_safe
+    link_text = [TagIcon.new(tag.name, self).image_tag, escape_once(tag.name)].compact.join(' ').html_safe
 
     link_to link_text, (tag.machine_tag.url || internal_url), class: link_classes.compact.join(' ')
   end
   private :tag_link
 
-  def tag_icon(tag_name)
-    return unless icon_exists_for?(tag_name)
-    image_tag(asset_path(tag_icon_path(tag_name)), title: tag_name)
-  end
-  private :tag_icon
+  class TagIcon < Struct.new(:name, :context)
+    def image_tag
+      return unless exists?
+      context.image_tag(image_path, title: name)
+    end
 
-  def icon_exists_for?(tag_name)
-    !!Rails.application.assets[tag_icon_path(tag_name)]
-  end
-  private :icon_exists_for?
+    private
 
-  def tag_icon_path(tag_name)
-    "tag_icons/#{tag_name}.png"
+    def exists?
+      !!Rails.application.assets[image_path]
+    end
+
+    def image_path
+      "tag_icons/#{name}.png"
+    end
   end
-  private :tag_icon_path
 
   def display_tag_icons(event)
     get_tag_icon_links(event).join(' ').html_safe
@@ -42,7 +43,7 @@ module TagsHelper
 
   def get_tag_icon_links(event)
     event.tag_list.map do |tag_name|
-      icon = tag_icon(tag_name)
+      icon = TagIcon.new(tag_name, self).image_tag
       link_to(icon, tag_events_path(tag_name)) if icon
     end
   end

--- a/app/helpers/calagator/tags_helper.rb
+++ b/app/helpers/calagator/tags_helper.rb
@@ -10,15 +10,24 @@ module TagsHelper
 
   class TagLink < Struct.new(:class_name, :tag, :context)
     def render
-      internal_url = "/#{class_name}/tag/#{tag.name}"
-
-      link_classes = ["p-category"]
-      link_classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
-
-      icon = TagIcon.new(tag.name, context)
-      link_text = [icon.exists? && icon.image_tag, context.escape_once(tag.name)].compact.join(' ').html_safe
-
       context.link_to link_text, (tag.machine_tag.url || internal_url), class: link_classes.compact.join(' ')
+    end
+
+    private
+
+    def link_text
+      icon = TagIcon.new(tag.name, context)
+      [icon.exists? && icon.image_tag, context.escape_once(tag.name)].compact.join(' ').html_safe
+    end
+
+    def internal_url
+      "/#{class_name}/tag/#{tag.name}"
+    end
+
+    def link_classes
+      classes = ["p-category"]
+      classes += ["external", tag.machine_tag.namespace, tag.machine_tag.predicate] if tag.machine_tag.url
+      classes
     end
   end
 

--- a/spec/helpers/calagator/tags_helper_spec.rb
+++ b/spec/helpers/calagator/tags_helper_spec.rb
@@ -12,63 +12,18 @@ describe TagsHelper, type: :helper do
     end
   end
 
-  describe "#icon_exists_for?" do
-    it "should return true if there is a PNG file in tag_icons with the name of the argument" do
-      expect(helper.icon_exists_for?("pizza")).to eq true
-    end
-
-    it "should return false if there is not a PNG file in tag_icons with the name of the argument" do
-      expect(helper.icon_exists_for?("no_image")).to eq false
-    end
-  end
-
-  shared_context "tag icons" do
+  describe "#display_tag_icons" do
     before do
       @event = FactoryGirl.create(:event, :tag_list => ['ruby', 'pizza'])
       @event2 = FactoryGirl.create(:event, :tag_list => ['no_image', 'also_no_image'])
       @untagged_event = Event.new
     end
-  end
-
-  describe "#get_tag_icon_links" do
-    include_context "tag icons"
-
-    it "should generate an array of image tags" do
-      helper.get_tag_icon_links(@event).each do |item|
-        expect(item).to include "<img "
-      end
-    end
-
-    it "should generate an array of link tags" do
-      helper.get_tag_icon_links(@event).each do |item|
-        expect(item).to include "<a "
-      end
-    end
-
-    it "should generate items for each tag that has a corresponding image" do
-      expect(helper.get_tag_icon_links(@event)[0]).to include "Ruby"
-      expect(helper.get_tag_icon_links(@event)[0]).to include "ruby.png"
-      expect(helper.get_tag_icon_links(@event)[1]).to include "Pizza"
-      expect(helper.get_tag_icon_links(@event)[1]).to include "pizza.png"
-    end
-
-    it "should return nil values for tags that do not correspond to images" do
-      expect(helper.get_tag_icon_links(@event2)).to eq [nil, nil]
-    end
-
-    it "should return a blank array if event has no tags" do
-      expect(helper.get_tag_icon_links(@untagged_event)).to eq []
-    end
-  end
-
-  describe "#display_tag_icons" do
-    include_context "tag icons"
 
     it "should render image tags inline and whitespace separated" do
-      expect(helper.display_tag_icons(@event)).to include "Ruby"
-      expect(helper.display_tag_icons(@event)).to include "ruby.png"
-      expect(helper.display_tag_icons(@event)).to include "Pizza"
-      expect(helper.display_tag_icons(@event)).to include "pizza.png"
+      expect(helper.display_tag_icons(@event)).to match_dom_of \
+        %(<a href="/events/tag/ruby"><img title="ruby" src="/assets/tag_icons/ruby.png" alt="Ruby" /></a> ) +
+        %(<a href="/events/tag/pizza"><img title="pizza" src="/assets/tag_icons/pizza.png" alt="Pizza" /></a>)
+
     end
 
     it "should render nothing if no image tags" do


### PR DESCRIPTION
* Extract `TagIcon` and `TagLink` helper classes to encapsulate details and reduce helper method surface area.
* Improve tests with better assertions, and only test helpers via the public API.