### PR TITLE
Upgrade rspec-activemodel-mocks; remove patch

### DIFF
--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_dependency "lucene_query", "0.1"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
-  s.add_development_dependency "rspec-activemodel-mocks", "~> 1.0"
+  s.add_development_dependency "rspec-activemodel-mocks", "~> 1.0.2"
   s.add_development_dependency "rspec-its", "~> 1.1"
   s.add_development_dependency "rspec-rails", "~> 3.2"
   s.add_development_dependency "rspec-collection_matchers", "~> 1.1"

--- a/spec/support/rspec-activemodel-mocks_patch.rb
+++ b/spec/support/rspec-activemodel-mocks_patch.rb
@@ -1,9 +1,0 @@
-# Manually applied the patch from https://github.com/jdelStrother/rspec-activemodel-mocks/commit/1211c347c5a574739616ccadf4b3b54686f9051f
-if Gem.loaded_specs['rspec-activemodel-mocks'].version.to_s != "1.0.1"
-  raise "RSpec::ActiveModel::Mocks version has changed, please check if the behavior has already been fixed: https://github.com/rspec/rspec-activemodel-mocks/pull/10
-If so, this patch might be obsolete."
-end
-
-RSpec::ActiveModel::Mocks::Mocks::ActiveRecordInstanceMethods.class_eval do
-  alias_method :_read_attribute, :[]
-end


### PR DESCRIPTION
Remove temporary monkey patch to rspec-activemodel-mocks, as the issue has now been fixed upstream.