### PR TITLE
Refactor VenuesController

### DIFF
--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -71,8 +71,7 @@ class VenuesController < Calagator::ApplicationController
     end
 
     def redirect_to_progenitor
-      return unless venue.duplicate?
-      redirect_to venue.progenitor
+      redirect_to venue.progenitor if venue.duplicate?
     end
 
     def render_venue

--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -7,6 +7,7 @@ class VenuesController < Calagator::ApplicationController
   include DuplicateChecking::ControllerActions
   require_admin only: [:duplicates, :squash_many_duplicates]
 
+
   # GET /venues
   def index
     @search = Venue::Search.new(params.permit!)
@@ -28,6 +29,7 @@ class VenuesController < Calagator::ApplicationController
   end
   private :render_venues
 
+
   # GET /autocomplete via AJAX
   def autocomplete
     @venues = Venue
@@ -39,10 +41,12 @@ class VenuesController < Calagator::ApplicationController
     render json: @venues, callback: params[:callback]
   end
 
+
   # GET /venues/map
   def map
     @venues = Venue.non_duplicates.in_business
   end
+
 
   # GET /venues/1
   before_action :show_all_if_not_found, :ensure_progenitor, only: :show
@@ -72,16 +76,19 @@ class VenuesController < Calagator::ApplicationController
     end
   end
 
+
   # GET /venues/new
   def new
     venue
     render layout: params[:layout] != "false"
   end
 
+
   # GET /venues/1/edit
   def edit
     venue
   end
+
 
   # POST /venues, # PUT /venues/1
   before_action :prevent_evil_robots, only: [:create, :update]
@@ -120,6 +127,7 @@ class VenuesController < Calagator::ApplicationController
     Event.find_by_id(params[:from_event])
   end
   private :from_event
+
 
   # DELETE /venues/1
   before_action :prevent_destruction_of_venue_with_events, only: :destroy

--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -81,8 +81,12 @@ class VenuesController < Calagator::ApplicationController
         format.html
         format.xml  { render xml: venue }
         format.json { render json: venue, callback: params[:callback] }
-        format.ics  { render ics: venue.events.order("start_time ASC") }
+        format.ics  { render ics: venue_events }
       end
+    end
+
+    def venue_events
+      venue.events.order(:start_time)
     end
   end
 

--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -66,9 +66,8 @@ class VenuesController < Calagator::ApplicationController
 
     def show_all_if_not_found
       return if venue
-    rescue ActiveRecord::RecordNotFound => e
-      flash[:failure] = e.to_s
-      redirect_to venues_path
+    rescue ActiveRecord::RecordNotFound => exception
+      redirect_to venues_path, flash: { failure: exception.to_s }
     end
 
     def redirect_to_progenitor

--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -8,23 +8,27 @@ class VenuesController < Calagator::ApplicationController
   require_admin only: [:duplicates, :squash_many_duplicates]
 
   # GET /venues
-  # GET /venues.xml
   def index
     @search = Venue::Search.new(params.permit!)
     @venues = @search.venues
 
     flash[:failure] = @search.failure_message
     return redirect_to venues_path if @search.hard_failure?
+    render_venues @venues
+  end
 
+  def render_venues venues
     respond_to do |format|
       format.html # index.html.erb
       format.kml  # index.kml.erb
-      format.xml  { render :xml  => @venues }
-      format.json { render :json => @venues, :callback => params[:callback] }
-      format.js   { render :json => @venues, :callback => params[:callback] }
+      format.xml  { render xml:  venues }
+      format.json { render json: venues, callback: params[:callback] }
+      format.js   { render json: venues, callback: params[:callback] }
     end
   end
+  private :render_venues
 
+  # GET /autocomplete via AJAX
   def autocomplete
     @venues = Venue
       .non_duplicates
@@ -32,9 +36,7 @@ class VenuesController < Calagator::ApplicationController
       .where(["LOWER(title) LIKE ?", "%#{params[:term]}%".downcase])
       .order('LOWER(title)')
 
-    respond_to do |format|
-      format.json { render :json => @venues, :callback => params[:callback] }
-    end
+    render json: @venues, callback: params[:callback]
   end
 
   # GET /venues/map
@@ -43,93 +45,109 @@ class VenuesController < Calagator::ApplicationController
   end
 
   # GET /venues/1
-  # GET /venues/1.xml
-  def show
-    @venue = Venue.find(params[:id])
+  before_action :show_all_if_not_found, :ensure_progenitor, only: :show
 
-    return redirect_to @venue.duplicate_of if @venue.duplicate?
-
-    respond_to do |format|
-      format.html
-      format.xml  { render xml: @venue }
-      format.json { render json: @venue, callback: params[:callback] }
-      format.ics  { render ics: @venue.events.order("start_time ASC") }
-    end
-
+  def show_all_if_not_found
+    venue
   rescue ActiveRecord::RecordNotFound => e
     flash[:failure] = e.to_s
     redirect_to venues_path
+    false
+  end
+  private :show_all_if_not_found
+
+  def ensure_progenitor
+    return unless venue.duplicate?
+    redirect_to venue.progenitor
+    false
+  end
+  private :ensure_progenitor
+
+  def show
+    respond_to do |format|
+      format.html
+      format.xml  { render xml: venue }
+      format.json { render json: venue, callback: params[:callback] }
+      format.ics  { render ics: venue.events.order("start_time ASC") }
+    end
   end
 
   # GET /venues/new
-  # GET /venues/new.xml
   def new
-    @venue = Venue.new
+    venue
     render layout: params[:layout] != "false"
   end
 
   # GET /venues/1/edit
   def edit
-    @venue = Venue.find(params[:id])
+    venue
   end
 
-  # POST /venues
-  # POST /venues.xml
+  # POST /venues, # PUT /venues/1
+  before_action :prevent_evil_robots, only: [:create, :update]
+
+  def prevent_evil_robots
+    return unless params[:trap_field].present?
+    flash[:failure] = "<h3>Evil Robot</h3> We didn't save this venue because we think you're an evil robot. If you're really not an evil robot, look at the form instructions more carefully. If this doesn't work please file a bug report and let us know."
+    render_failure
+    false
+  end
+  private :prevent_evil_robots
+
   def create
-    @venue = Venue.new
-    create_or_update
+    venue.attributes = params.permit![:venue].to_h
+    venue.save ? render_success : render_failure
   end
+  alias_method :update, :create
 
-  # PUT /venues/1
-  # PUT /venues/1.xml
-  def update
-    @venue = Venue.find(params[:id])
-    create_or_update
-  end
-
-  def create_or_update
-    @venue.attributes = params.permit![:venue] || {}
+  def render_success
     respond_to do |format|
-      if !evil_robot? && @venue.save
-        format.html { redirect_to from_event || @venue, flash: { success: "Venue was successfully saved." } }
-        format.xml  { render xml: @venue, status: :created, location: @venue }
-      else
-        format.html { render action: @venue.new_record? ? "new" : "edit" }
-        format.xml  { render xml: @venue.errors, status: :unprocessable_entity }
-      end
+      format.html { redirect_to from_event || venue, flash: { success: "Venue was successfully saved." } }
+      format.xml  { render xml: venue, status: :created, location: venue }
     end
   end
+  private :render_success
+
+  def render_failure
+    respond_to do |format|
+      format.html { render action: venue.new_record? ? "new" : "edit" }
+      format.xml  { render xml: venue.errors, status: :unprocessable_entity }
+    end
+  end
+  private :render_failure
+
+  def from_event
+    Event.find_by_id(params[:from_event])
+  end
+  private :from_event
 
   # DELETE /venues/1
-  # DELETE /venues/1.xml
-  def destroy
-    @venue = Venue.find(params[:id])
+  before_action :prevent_destruction_of_venue_with_events, only: :destroy
 
-    if @venue.events.any?
-      message = "Cannot destroy venue that has associated events, you must reassociate all its events first."
-      respond_to do |format|
-        format.html { redirect_to @venue, flash: { failure: message } }
-        format.xml  { render xml: message, status: :unprocessable_entity }
-      end
-    else
-      @venue.destroy
-      respond_to do |format|
-        format.html { redirect_to venues_path, flash: { success: %("#{@venue.title}" has been deleted) } }
-        format.xml  { head :ok }
-      end
+  def prevent_destruction_of_venue_with_events
+    return unless venue.events.any?
+
+    message = "Cannot destroy venue that has associated events, you must reassociate all its events first."
+    respond_to do |format|
+      format.html { redirect_to venue, flash: { failure: message } }
+      format.xml  { render xml: message, status: :unprocessable_entity }
+    end
+    false
+  end
+  private :prevent_destruction_of_venue_with_events
+
+  def destroy
+    venue.destroy
+    respond_to do |format|
+      format.html { redirect_to venues_path, flash: { success: %("#{venue.title}" has been deleted) } }
+      format.xml  { head :ok }
     end
   end
 
   private
 
-  def evil_robot?
-    if params[:trap_field].present?
-      flash[:failure] = "<h3>Evil Robot</h3> We didn't save this venue because we think you're an evil robot. If you're really not an evil robot, look at the form instructions more carefully. If this doesn't work please file a bug report and let us know."
-    end
-  end
-
-  def from_event
-    Event.find_by_id(params[:from_event])
+  def venue
+    @venue ||= params[:id] ? Venue.find(params[:id]) : Venue.new
   end
 end
 

--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -110,7 +110,7 @@ class VenuesController < Calagator::ApplicationController
 
   class CreateOrUpdate < SimpleDelegator
     def call
-      block_spammers or save
+      block_spammers or (save and render_success) or render_failure
     end
 
     private
@@ -122,8 +122,7 @@ class VenuesController < Calagator::ApplicationController
     end
 
     def save
-      venue.attributes = params.permit![:venue].to_h
-      venue.save ? render_success : render_failure
+      venue.update_attributes params.permit![:venue].to_h
     end
 
     def render_success

--- a/spec/controllers/calagator/venues_controller_spec.rb
+++ b/spec/controllers/calagator/venues_controller_spec.rb
@@ -8,23 +8,20 @@ describe VenuesController, :type => :controller do
 
   render_views
 
-  it "should redirect duplicate venues to their master" do
-    venue_master = FactoryGirl.create(:venue)
-    venue_duplicate = FactoryGirl.create(:venue)
+  context "concerning duplicates" do
+    let!(:venue_master) { FactoryGirl.create(:venue) }
+    let!(:venue_duplicate) { FactoryGirl.create(:venue, duplicate_of: venue_master) }
 
-    # No redirect when they're unique
-    get 'show', :id => venue_duplicate.id
-    expect(response).not_to be_redirect
-    expect(assigns(:venue).id).to eq venue_duplicate.id
+    it "redirects duplicate venues to their master" do
+      get 'show', id: venue_duplicate.id
+      expect(response).to redirect_to(venue_url(venue_master.id))
+    end
 
-    # Mark as duplicate
-    venue_duplicate.duplicate_of = venue_master
-    venue_duplicate.save!
-
-    # Now check that redirection happens
-    get 'show', :id => venue_duplicate.id
-    expect(response).to be_redirect
-    expect(response).to redirect_to(venue_url(venue_master.id))
+    it "doesn't redirect non-duplicates" do
+      get 'show', id: venue_master.id
+      expect(response).not_to be_redirect
+      expect(assigns(:venue).id).to eq venue_master.id
+    end
   end
 
   context "with admin auth for duplicates" do


### PR DESCRIPTION
Well this has been a very interesting exploration of how to break up a complex controller. Virtually everything that was non-controllery had been extracted out of `VenuesController`, and it still was getting a D in code climate! There really is a lot going on, and it is all controller concerns: when to redirect and where, what to render and how, accessing params, etc.

I've been at an impasse for a while, trying to figure out how to break this down, and realized the issue is really that we have _one_ class for _nine_ actions! Extracting a private method for one action pollutes the namespace for the other eight... not exactly SRP. However, there is a lot to be said for the value of Rails conventions, so I didn't want to break from that completely by doing something like one controller per action. Today I experimented with a new approach that I think has turned out to be very effective: **wrap the controller at runtime with a new class that just contains logic for that particular action**... somewhat reminiscent of the DCI paradigm.

IMO, the results have been very pleasing. We're operating at a more consistent level of abstraction, complex actions can have their own encapsulated sandbox to extract methods and all that good OO stuff, and Rails conventions are still in place.

Code climate seems to agree, bumping our score from a 3.66 up to a 3.8 from just changing this file alone! https://codeclimate.com/github/calagator/calagator/compare/refactor_venues_controller#ratings

All that said, this is admittedly somewhat unorthodox... I don't think I've ever seen this before in the wild, but Rails controllers haven't exactly been a hotbed of experimentation, historically.

What do you think?