### PR TITLE
Refactor Source::Parser:Ical

### DIFF
--- a/app/models/calagator/source.rb
+++ b/app/models/calagator/source.rb
@@ -38,10 +38,10 @@ class Source < ActiveRecord::Base
 
   # Create events for this source. Returns the events created. URL must be set
   # for this source for this to work.
-  def create_events!(opts={})
+  def create_events!
     save!
-    events = to_events(opts).select(&:valid?)
-    events.reject!(&:old?) if opts[:skip_old]
+    events = to_events.select(&:valid?)
+    events.reject!(&:old?)
     events.each(&:save!)
     events
   end
@@ -56,17 +56,10 @@ class Source < ActiveRecord::Base
   end
 
   # Returns an Array of Event objects that were read from this source.
-  #
-  # Options:
-  # * :url -- URL of data to import. Defaults to record's #url attribute.
-  # * :skip_old -- Should old events be skipped? Default is true.
-  def to_events(opts={})
+  def to_events
     raise ActiveRecord::RecordInvalid, self unless valid?
-
     self.imported_at = Time.now
-    opts[:url] ||= self.url
-    opts[:source] = self
-    Source::Parser.to_events(opts)
+    Source::Parser.to_events(url: url, source: self)
   end
 
   # Return the name of the source, which can be its title or URL.

--- a/app/models/calagator/source.rb
+++ b/app/models/calagator/source.rb
@@ -40,10 +40,7 @@ class Source < ActiveRecord::Base
   # for this source for this to work.
   def create_events!
     save!
-    events = to_events.select(&:valid?)
-    events.reject!(&:old?)
-    events.each(&:save!)
-    events
+    to_events.select{ |event| event.valid? && !event.old? }.each(&:save!)
   end
 
   # Normalize the URL.

--- a/app/models/calagator/source/parser.rb
+++ b/app/models/calagator/source/parser.rb
@@ -9,16 +9,12 @@ require "open-uri"
 # directly, use a subclass of Parser to do the parsing instead.
 module Calagator
 
-class Source::Parser < Struct.new(:opts)
+class Source::Parser < Struct.new(:url, :source)
   # Return an Array of unsaved Event instances.
-  #
-  # Options: (these vary between specific parsers)
-  # * :url - URL string to read as parser input.
-  # * :content - String to read as parser input.
-  def self.to_events(opts)
+  def self.to_events(url: nil, source: nil)
     # Return events from the first parser that suceeds
-    events = matched_parsers(opts[:url]).lazy.collect { |parser|
-      parser.new(opts).to_events
+    events = matched_parsers(url).lazy.collect { |parser|
+      parser.new(url, source).to_events
     }.detect(&:present?)
 
     events || []

--- a/app/models/calagator/source/parser/facebook.rb
+++ b/app/models/calagator/source/parser/facebook.rb
@@ -21,17 +21,17 @@ class Source::Parser::Facebook < Source::Parser
     }
 
   def to_events
-    return unless data = to_events_api_helper(opts[:url]) do |event_id|
+    return unless data = to_events_api_helper(url) do |event_id|
       "http://graph.facebook.com/#{event_id}"
     end
 
     raise ::Source::Parser::HttpAuthenticationRequiredError if data['parsed_response'] === false
 
     event = Event.new({
-      source:      opts[:source],
+      source:      source,
       title:       data['name'],
       description: data['description'],
-      url:         opts[:url],
+      url:         url,
       tag_list:    "facebook:event=#{data['id']}",
       venue:       to_venue(data),
 
@@ -50,7 +50,7 @@ class Source::Parser::Facebook < Source::Parser
     return if fields.blank?
 
     venue = Venue.new({
-      source:         opts[:source],
+      source:         source,
       title:          data['location'],
       street_address: fields['street'],
       locality:       fields['city'],

--- a/app/models/calagator/source/parser/hcal.rb
+++ b/app/models/calagator/source/parser/hcal.rb
@@ -23,7 +23,7 @@ class Source::Parser::Hcal < Source::Parser
   def to_events
     hcals.map do |hcal|
       event = Event.new
-      event.source = opts[:source]
+      event.source = source
       EVENT_TO_HCALENDAR_FIELD_MAP.each do |field, mofo_field|
         next unless hcal.respond_to?(mofo_field)
         next unless value = decoded_field(hcal, mofo_field)
@@ -43,7 +43,7 @@ class Source::Parser::Hcal < Source::Parser
     when :dtstart
       HTMLEntities.new.decode(raw_field)
     when :location
-      to_venue(opts.merge(:value => raw_field))
+      to_venue(raw_field)
     else
       raw_field
     end
@@ -60,10 +60,10 @@ class Source::Parser::Hcal < Source::Parser
   #
   # Options:
   # * :value -- hCard or string location
-  def to_venue(opts)
+  def to_venue(value)
     venue = Venue.new
-    venue.source = opts[:source]
-    case raw = opts[:value]
+    venue.source = source
+    case raw = value
     when String
       venue.title = raw
     when HCard
@@ -99,7 +99,7 @@ class Source::Parser::Hcal < Source::Parser
   end
 
   def hcals
-    content = self.class.read_url(opts[:url])
+    content = self.class.read_url(url)
     something = hCalendar.find(:text => content)
     something.is_a?(hCalendar) ? [something] : something
   end

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -22,18 +22,11 @@ class Source::Parser::Ical < Source::Parser
 
   def to_events
     return false unless calendars
-
-    events = calendars.flat_map do |calendar|
-      calendar.events.map do |component|
-        vevent = VEvent.new(component)
-        next if vevent.old?
-        vevent.to_event(calendar, source)
-      end
-    end
-
-    events.compact.uniq do |event|
+    events.map do |event|
       event = event_or_duplicate(event)
       event.venue = venue_or_duplicate(event.venue) if event.venue
+      event
+    end.uniq do |event|
       [event.attributes, event.venue.try(:attributes)]
     end
   end
@@ -50,6 +43,16 @@ class Source::Parser::Ical < Source::Parser
   rescue Exception => exception
     return false if exception.message =~ /Invalid icalendar file/ # Invalid data, give up.
     raise # Unknown error, reraise
+  end
+
+  def events
+    calendars.flat_map do |calendar|
+      calendar.events.map do |component|
+        vevent = VEvent.new(component)
+        next if vevent.old?
+        vevent.to_event(calendar, source)
+      end
+    end.compact
   end
 
   class VEvent < Struct.new(:component)

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -25,7 +25,7 @@ class Source::Parser::Ical < Source::Parser
 
     events = calendars.flat_map do |calendar|
       calendar.events.map do |component|
-        next if skip_old? and old?(component)
+        next if old?(component)
         component_to_event(component, calendar)
       end
     end
@@ -36,11 +36,6 @@ class Source::Parser::Ical < Source::Parser
   end
 
   private
-
-  def skip_old?
-    # Skip old events by default
-    true unless opts[:skip_old] == false
-  end
 
   def old?(component)
     cutoff = Time.now.yesterday

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -44,8 +44,9 @@ class Source::Parser::Ical < Source::Parser
 
   def calendars
     @calendars ||= begin
-      content = self.class.read_url(url).gsub(/\r\n/, "\n")
-      content = munge_gmt_dates(content)
+      content = self.class.read_url(url)
+      content.gsub! /\r\n/, "\n" # normalize line endings
+      content.gsub! /;TZID=GMT:(.*)/, ':\1Z' # normalize timezones
       RiCal.parse_string(content)
     end
   rescue Exception => exception
@@ -112,10 +113,6 @@ class Source::Parser::Ical < Source::Parser
   rescue => exception
     Rails.logger.info("Source::Parser::Ical.to_events : Failed to parse content_venue for event -- #{exception}")
     nil
-  end
-
-  def munge_gmt_dates(content)
-    content.gsub(/;TZID=GMT:(.*)/, ':\1Z')
   end
 
   # Return an Venue extracted from an iCalendar input.

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -97,6 +97,40 @@ class Source::Parser::Ical < Source::Parser
       content.match(/^UID:(?<uid>.+)$/)[:uid]
     end
 
+    def name
+      vcard_hash['NAME']
+    end
+
+    def address
+      vcard_hash['ADDRESS']
+    end
+
+    def city
+      vcard_hash['CITY']
+    end
+
+    def region
+      vcard_hash['REGION']
+    end
+
+    def postalcode
+      vcard_hash['POSTALCODE']
+    end
+
+    def country
+      vcard_hash['COUNTRY']
+    end
+
+    def geo
+      vcard_hash['GEO']
+    end
+
+    def url
+      vcard_hash['URL']
+    end
+
+    private
+
     def vcard_hash
       # Only use first vcard of a VVENUE
       vcard = RiCal.parse_string(content).first
@@ -106,8 +140,6 @@ class Source::Parser::Ical < Source::Parser
 
       hash_from_vcard_lines(vcard_lines)
     end
-
-    private
 
     VCARD_LINES_RE = /^(?<key>[^;]+?)(?<qualifier>;[^:]*?)?:(?<value>.*)$/
 
@@ -168,15 +200,15 @@ class Source::Parser::Ical < Source::Parser
 
       # VVENUE entries are considered just Vcards,
       # treating them as such.
-      if vvenue && vcard_hash = vvenue.vcard_hash
-        location = vcard_hash['GEO'].split(/;/).map(&:to_f)
+      if vvenue
+        location = vvenue.geo.split(/;/).map(&:to_f)
         venue.attributes = {
-          title:          vcard_hash['NAME'],
-          street_address: vcard_hash['ADDRESS'],
-          locality:       vcard_hash['CITY'],
-          region:         vcard_hash['REGION'],
-          postal_code:    vcard_hash['POSTALCODE'],
-          country:        vcard_hash['COUNTRY'],
+          title:          vvenue.name,
+          street_address: vvenue.address,
+          locality:       vvenue.city,
+          region:         vvenue.region,
+          postal_code:    vvenue.postalcode,
+          country:        vvenue.country,
           latitude:       location.first,
           longitude:      location.last,
         }

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -23,7 +23,10 @@ class Source::Parser::Ical < Source::Parser
 
   def to_events
     return false unless calendars
-    dedup(events(calendars))
+    events = calendars.flat_map(&:events).each do |event|
+      event.source = source
+    end
+    dedup(events)
   end
 
   private
@@ -41,12 +44,6 @@ class Source::Parser::Ical < Source::Parser
     self.class.read_url(url).tap do |content|
       content.gsub! /\r\n/, "\n" # normalize line endings
       content.gsub! /;TZID=GMT:(.*)/, ':\1Z' # normalize timezones
-    end
-  end
-
-  def events(calendars)
-    calendars.flat_map(&:events).each do |event|
-      event.source = source
     end
   end
 

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -22,13 +22,7 @@ class Source::Parser::Ical < Source::Parser
 
   def to_events
     return false unless calendars
-    events.map do |event|
-      event = event_or_duplicate(event)
-      event.venue = venue_or_duplicate(event.venue) if event.venue
-      event
-    end.uniq do |event|
-      [event.attributes, event.venue.try(:attributes)]
-    end
+    dedup(events)
   end
 
   private
@@ -53,6 +47,14 @@ class Source::Parser::Ical < Source::Parser
         vevent.to_event(calendar, source)
       end
     end.compact
+  end
+
+  def dedup(events)
+    events.map do |event|
+      event = event_or_duplicate(event)
+      event.venue = venue_or_duplicate(event.venue) if event.venue
+      event
+    end.uniq
   end
 
   class VEvent < Struct.new(:component)

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -1,3 +1,5 @@
+require "calagator/vcalendar"
+
 # == Source::Parser::Ical
 #
 # Reads iCalendar events.
@@ -48,116 +50,7 @@ class Source::Parser::Ical < Source::Parser
     end.uniq
   end
 
-  class VCalendar < Struct.new(:ri_cal_calendar)
-    def self.parse(raw_ical)
-      raw_ical.gsub! /\r\n/, "\n" # normalize line endings
-      raw_ical.gsub! /;TZID=GMT:(.*)/, ':\1Z' # normalize timezones
-
-      RiCal.parse_string(raw_ical).map do |ri_cal_calendar|
-        VCalendar.new(ri_cal_calendar)
-      end
-
-    rescue Exception => exception
-      return false if exception.message =~ /Invalid icalendar file/ # Invalid data, give up.
-      raise # Unknown error, reraise
-    end
-
-    def vevents
-      ri_cal_calendar.events.map do |ri_cal_event|
-        VEvent.new(ri_cal_event, vvenues)
-      end
-    end
-
-    VENUE_CONTENT_RE = /^BEGIN:VVENUE$.*?^END:VVENUE$/m
-
-    def vvenues
-      ri_cal_calendar.to_s.scan(VENUE_CONTENT_RE).map do |raw_ical_venue|
-        VVenue.new(raw_ical_venue)
-      end
-    end
-  end
-
-  class VEvent < Struct.new(:ri_cal_event, :vvenues)
-    def old?
-      cutoff = Time.now.yesterday
-      (ri_cal_event.dtend || ri_cal_event.dtstart).to_time < cutoff
-    end
-
-    delegate :location, :summary, :description, :url, to: :ri_cal_event
-
-    # translate the start and end dates correctly depending on whether it's a floating or fixed timezone
-
-    def start_time
-      if ri_cal_event.dtstart_property.tzid
-        ri_cal_event.dtstart
-      else
-        Time.zone.parse(ri_cal_event.dtstart_property.value)
-      end
-    end
-
-    def end_time
-      if ri_cal_event.dtstart_property.tzid
-        ri_cal_event.dtend
-      elsif ri_cal_event.dtend_property
-        Time.zone.parse(ri_cal_event.dtend_property.value)
-      elsif ri_cal_event.duration
-        ri_cal_event.duration_property.add_to_date_time_value(start_time)
-      else
-        start_time
-      end
-    end
-
-    def vvenue
-      vvenues.find { |venue| venue.uid == venue_uid } if venue_uid
-    end
-
-    private
-
-    def venue_uid
-      ri_cal_event.location_property.try(:params).try(:[], "VVENUE")
-    end
-  end
-
-  class VVenue < Struct.new(:raw_ical_venue)
-    def uid
-      raw_ical_venue.match(/^UID:(?<uid>.+)$/)[:uid]
-    end
-
-    def method_missing(method, *args, &block)
-      vcard_hash_key = method.to_s.upcase
-      return vcard_hash[vcard_hash_key] if vcard_hash.has_key?(vcard_hash_key)
-      super
-    end
-
-    def respond_to?(method, include_private = false)
-      vcard_hash_key = method.to_s.upcase
-      vcard_hash.has_key?(vcard_hash_key) || super
-    end
-
-    private
-
-    def vcard_hash
-      # Only use first vcard of a VVENUE
-      vcard = RiCal.parse_string(raw_ical_venue).first
-
-      # Extract all properties into an array of "KEY;meta-qualifier:value" strings
-      vcard_lines = vcard.export_properties_to(StringIO.new(''))
-
-      hash_from_vcard_lines(vcard_lines)
-    end
-
-    VCARD_LINES_RE = /^(?<key>[^;]+?)(?<qualifier>;[^:]*?)?:(?<value>.*)$/
-
-    def hash_from_vcard_lines(vcard_lines)
-      vcard_lines.reduce({}) do |vcard_hash, vcard_line|
-        vcard_line.match(VCARD_LINES_RE) do |match|
-          vcard_hash[match[:key]] ||= match[:value]
-        end
-        vcard_hash
-      end
-    end
-  end
-
+  # Converts a VEvent instance into an Event
   class EventParser < Struct.new(:vevent)
     def to_event
       Event.new({
@@ -170,11 +63,7 @@ class Source::Parser::Ical < Source::Parser
     end
   end
 
-  # Return an Venue extracted from an iCalendar input.
-  #
-  # Arguments:
-  # * value - String with iCalendar data to parse which contains a VVENUE item.
-  # * fallback - String to use as the title for the location if the +value+ doesn't contain a VVENUE.
+  # Converts a VVenue instance into a Venue
   class VenueParser < Struct.new(:vvenue, :fallback)
     def to_venue
       from_vvenue or from_fallback or return

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -97,36 +97,15 @@ class Source::Parser::Ical < Source::Parser
       content.match(/^UID:(?<uid>.+)$/)[:uid]
     end
 
-    def name
-      vcard_hash['NAME']
+    def method_missing(method, *args, &block)
+      vcard_hash_key = method.to_s.upcase
+      return vcard_hash[vcard_hash_key] if vcard_hash.has_key?(vcard_hash_key)
+      super
     end
 
-    def address
-      vcard_hash['ADDRESS']
-    end
-
-    def city
-      vcard_hash['CITY']
-    end
-
-    def region
-      vcard_hash['REGION']
-    end
-
-    def postalcode
-      vcard_hash['POSTALCODE']
-    end
-
-    def country
-      vcard_hash['COUNTRY']
-    end
-
-    def geo
-      vcard_hash['GEO']
-    end
-
-    def url
-      vcard_hash['URL']
+    def respond_to?(method, include_private = false)
+      vcard_hash_key = method.to_s.upcase
+      vcard_hash.has_key?(vcard_hash_key) || super
     end
 
     private

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -42,11 +42,11 @@ class Source::Parser::Ical < Source::Parser
   def events
     calendars.flat_map do |calendar|
       calendar.events.map do |component|
-        vevent = VEvent.new(component)
-        next if vevent.old?
+        VEvent.new(component)
+      end.reject(&:old?).map do |vevent|
         vevent.to_event(calendar, source)
       end
-    end.compact
+    end
   end
 
   def dedup(events)

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -21,7 +21,7 @@ class Source::Parser::Ical < Source::Parser
   end
 
   def to_events
-    return false unless calendars = content_calendars
+    return false unless calendars
 
     events = calendars.flat_map do |calendar|
       calendar.events.map do |component|
@@ -42,10 +42,12 @@ class Source::Parser::Ical < Source::Parser
     (component.dtend || component.dtstart).to_time < cutoff
   end
 
-  def content_calendars
-    content = self.class.read_url(url).gsub(/\r\n/, "\n")
-    content = munge_gmt_dates(content)
-    RiCal.parse_string(content)
+  def calendars
+    @calendars ||= begin
+      content = self.class.read_url(url).gsub(/\r\n/, "\n")
+      content = munge_gmt_dates(content)
+      RiCal.parse_string(content)
+    end
   rescue Exception => exception
     return false if exception.message =~ /Invalid icalendar file/ # Invalid data, give up.
     raise # Unknown error, reraise

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -22,20 +22,15 @@ class Source::Parser::Ical < Source::Parser
   def to_events
     return false unless vcalendars
     events = vcalendars.flat_map(&:vevents).reject(&:old?).map do |vevent|
-      to_event(vevent)
-    end.each do |event|
+      event = EventParser.new(vevent).to_event
+      event.venue = VenueParser.new(vevent.vvenue, vevent.location).to_venue
       event.source = source
+      event
     end
     dedup(events)
   end
 
   private
-
-  def to_event(vevent)
-    event = EventParser.new(vevent).to_event
-    event.venue = VenueParser.new(vevent.vvenue, vevent.location).to_venue
-    event
-  end
 
   def vcalendars
     @vcalendars ||= VCalendar.parse(raw_ical)

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -69,9 +69,8 @@ class Source::Parser::Ical < Source::Parser
     end
 
     def to_event(calendar)
-      event = EventParser.parse(component)
-      venue = VenueParser.parse(content_venue(calendar), component.location)
-      event.venue = venue if venue
+      event = EventParser.new(component).to_event
+      event.venue = VenueParser.new(content_venue(calendar), component.location).to_venue
       event
     end
 
@@ -91,11 +90,7 @@ class Source::Parser::Ical < Source::Parser
   end
 
   class EventParser < Struct.new(:component)
-    def self.parse(component)
-      new(component).parse
-    end
-
-    def parse
+    def to_event
       Event.new({
         title:       component.summary,
         description: component.description,
@@ -136,11 +131,7 @@ class Source::Parser::Ical < Source::Parser
   # * value - String with iCalendar data to parse which contains a VVENUE item.
   # * fallback - String to use as the title for the location if the +value+ doesn't contain a VVENUE.
   class VenueParser < Struct.new(:value, :fallback)
-    def self.parse(value, fallback=nil)
-      new(value, fallback).parse
-    end
-
-    def parse
+    def to_venue
       venue = Venue.new
 
       # VVENUE entries are considered just Vcards,

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -15,9 +15,10 @@ class Source::Parser::Ical < Source::Parser
 
   VENUE_CONTENT_RE = /^BEGIN:VVENUE$.*?^END:VVENUE$/m
 
-  # Override Base::read_url to handle "webcal" scheme addresses.
+  # Override Source::Parser.read_url to handle "webcal" scheme addresses.
   def self.read_url(url)
-    super(url.gsub(/^webcal:/, 'http:'))
+    url.gsub!(/^webcal:/, 'http:')
+    super
   end
 
   def to_events

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -76,7 +76,6 @@ class Source::Parser::Ical < Source::Parser
 
     def from_vvenue
       return unless vvenue
-      location = vvenue.geo.split(/;/).map(&:to_f)
       Venue.new({
         title:          vvenue.name,
         street_address: vvenue.address,
@@ -84,8 +83,8 @@ class Source::Parser::Ical < Source::Parser
         region:         vvenue.region,
         postal_code:    vvenue.postalcode,
         country:        vvenue.country,
-        latitude:       location.first,
-        longitude:      location.last,
+        latitude:       vvenue.latitude,
+        longitude:      vvenue.longitude,
       }) do |venue|
         venue.geocode!
       end

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -39,8 +39,8 @@ class Source::Parser::Ical < Source::Parser
   end
 
   def to_event(vevent)
-    event = EventParser.new(vevent).to_event
-    event.venue = VenueParser.new(vevent.vvenue, vevent.location).to_venue
+    event = EventMapper.new(vevent).to_event
+    event.venue = VenueMapper.new(vevent.vvenue, vevent.location).to_venue
     event.source = source
     event
   end
@@ -54,7 +54,7 @@ class Source::Parser::Ical < Source::Parser
   end
 
   # Converts a VEvent instance into an Event
-  class EventParser < Struct.new(:vevent)
+  class EventMapper < Struct.new(:vevent)
     def to_event
       Event.new({
         title:       vevent.summary,
@@ -67,7 +67,7 @@ class Source::Parser::Ical < Source::Parser
   end
 
   # Converts a VVenue instance into a Venue
-  class VenueParser < Struct.new(:vvenue, :fallback)
+  class VenueMapper < Struct.new(:vvenue, :fallback)
     def to_venue
       from_vvenue or from_fallback or return
     end

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -28,15 +28,17 @@ class Source::Parser::Ical < Source::Parser
   private
 
   def calendars
-    @calendars ||= begin
-      content = self.class.read_url(url)
-      content.gsub! /\r\n/, "\n" # normalize line endings
-      content.gsub! /;TZID=GMT:(.*)/, ':\1Z' # normalize timezones
-      RiCal.parse_string(content)
-    end
+    @calendars ||= RiCal.parse_string(content)
   rescue Exception => exception
     return false if exception.message =~ /Invalid icalendar file/ # Invalid data, give up.
     raise # Unknown error, reraise
+  end
+
+  def content
+    self.class.read_url(url).tap do |content|
+      content.gsub! /\r\n/, "\n" # normalize line endings
+      content.gsub! /;TZID=GMT:(.*)/, ':\1Z' # normalize timezones
+    end
   end
 
   def events

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -22,7 +22,7 @@ class Source::Parser::Ical < Source::Parser
 
   def to_events
     return false unless calendars
-    dedup(events)
+    dedup(events(calendars))
   end
 
   private
@@ -41,7 +41,7 @@ class Source::Parser::Ical < Source::Parser
     end
   end
 
-  def events
+  def events(calendars)
     calendars.flat_map do |calendar|
       calendar.events.map do |component|
         VEvent.new(component)

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -23,13 +23,9 @@ class Source::Parser::Ical < Source::Parser
 
   def to_events
     return false unless vcalendars
-    events = vcalendars.flat_map(&:vevents).reject(&:old?).map do |vevent|
-      event = EventParser.new(vevent).to_event
-      event.venue = VenueParser.new(vevent.vvenue, vevent.location).to_venue
-      event.source = source
-      event
-    end
-    dedup(events)
+    current_vevents = vcalendars.flat_map(&:vevents).reject(&:old?)
+    current_events = current_vevents.map { |vevent| to_event(vevent) }
+    dedup(current_events)
   end
 
   private
@@ -40,6 +36,13 @@ class Source::Parser::Ical < Source::Parser
 
   def raw_ical
     self.class.read_url(url)
+  end
+
+  def to_event(vevent)
+    event = EventParser.new(vevent).to_event
+    event.venue = VenueParser.new(vevent.vvenue, vevent.location).to_venue
+    event.source = source
+    event
   end
 
   def dedup(events)

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -161,25 +161,16 @@ class Source::Parser::Ical < Source::Parser
       hash_from_vcard_lines(vcard_lines)
     end
 
+    VCARD_LINES_RE = /^(?<key>[^;]+?)(?<qualifier>;[^:]*?)?:(?<value>.*)$/
+
     # Return hash parsed from VCARD lines.
     #
     # Arguments:
     # * vcard_lines - Array of "KEY;meta-qualifier:value" strings.
     def hash_from_vcard_lines(vcard_lines)
       vcard_lines.reduce({}) do |vcard_hash, vcard_line|
-        if matcher = vcard_line.match(/^([^;]+?)(;[^:]*?)?:(.*)$/)
-          _, key, qualifier, value = *matcher
-
-          if qualifier
-            # Add entry for a key and its meta-qualifier
-            vcard_hash["#{key}#{qualifier}"] = value
-
-            # Add fallback entry for a key from the matching meta-qualifier, e.g. create key "foo" from contents of key with meta-qualifier "foo;bar".
-            vcard_hash[key] ||= value
-          else
-            # Add entry for a key without a meta-qualifier.
-            vcard_hash[key] = value
-          end
+        vcard_line.match(VCARD_LINES_RE) do |match|
+          vcard_hash[match[:key]] ||= match[:value]
         end
         vcard_hash
       end

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -30,12 +30,7 @@ class Source::Parser::Ical < Source::Parser
   private
 
   def calendars
-    @calendars ||= RiCal.parse_string(content).map do |calendar|
-      VCalendar.new(calendar)
-    end
-  rescue Exception => exception
-    return false if exception.message =~ /Invalid icalendar file/ # Invalid data, give up.
-    raise # Unknown error, reraise
+    @calendars ||= VCalendar.parse(content)
   end
 
   def content
@@ -54,6 +49,15 @@ class Source::Parser::Ical < Source::Parser
   end
 
   class VCalendar < Struct.new(:calendar)
+    def self.parse(content)
+      RiCal.parse_string(content).map do |calendar|
+        VCalendar.new(calendar)
+      end
+    rescue Exception => exception
+      return false if exception.message =~ /Invalid icalendar file/ # Invalid data, give up.
+      raise # Unknown error, reraise
+    end
+
     VENUE_CONTENT_RE = /^BEGIN:VVENUE$.*?^END:VVENUE$/m
 
     def events

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -62,8 +62,8 @@ class Source::Parser::Ical < Source::Parser
       url:         component.url,
       start_time:  normalized_start_time(component),
       end_time:    normalized_end_time(component),
+      venue:       to_venue(content_venue(component, calendar), component.location),
     })
-    event.venue = to_venue(content_venue(component, calendar), component.location)
     event_or_duplicate(event)
   end
 

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -62,6 +62,18 @@ class Source::Parser::Ical < Source::Parser
     event_or_duplicate(event)
   end
 
+  def content_venue(component, calendar)
+    content_venues = calendar.to_s.scan(VENUE_CONTENT_RE)
+
+    # finding the event venue id - VVENUE=V0-001-001423875-1@eventful.com
+    venue_uid = component.location_property.params["VVENUE"]
+    # finding in the content_venues array an item matching the uid
+    venue_uid ? content_venues.find{|content_venue| content_venue.match(/^UID:#{venue_uid}$/m)} : nil
+  rescue => exception
+    Rails.logger.info("Source::Parser::Ical.to_events : Failed to parse content_venue for event -- #{exception}")
+    nil
+  end
+
   class EventParser < Struct.new(:component, :source)
     def self.parse(component, source)
       new(component, source).parse
@@ -101,18 +113,6 @@ class Source::Parser::Ical < Source::Parser
         normalized_start_time(component)
       end
     end
-  end
-
-  def content_venue(component, calendar)
-    content_venues = calendar.to_s.scan(VENUE_CONTENT_RE)
-
-    # finding the event venue id - VVENUE=V0-001-001423875-1@eventful.com
-    venue_uid = component.location_property.params["VVENUE"]
-    # finding in the content_venues array an item matching the uid
-    venue_uid ? content_venues.find{|content_venue| content_venue.match(/^UID:#{venue_uid}$/m)} : nil
-  rescue => exception
-    Rails.logger.info("Source::Parser::Ical.to_events : Failed to parse content_venue for event -- #{exception}")
-    nil
   end
 
   # Return an Venue extracted from an iCalendar input.

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -109,8 +109,12 @@ class Source::Parser::Ical < Source::Parser
   # Arguments:
   # * value - String with iCalendar data to parse which contains a VVENUE item.
   # * fallback - String to use as the title for the location if the +value+ doesn't contain a VVENUE.
-  class VenueParser
+  class VenueParser < Struct.new(:value, :fallback)
     def self.parse(value, fallback=nil)
+      new(value, fallback).parse
+    end
+
+    def parse
       venue = Venue.new
 
       # VVENUE entries are considered just Vcards,
@@ -139,7 +143,9 @@ class Source::Parser::Ical < Source::Parser
       venue
     end
 
-    def self.vcard_hash_from_value(value)
+    private
+
+    def vcard_hash_from_value(value)
       value ||= ""
       return unless data = value.scan(VENUE_CONTENT_RE).first
 
@@ -159,7 +165,7 @@ class Source::Parser::Ical < Source::Parser
     #
     # Arguments:
     # * vcard_lines - Array of "KEY;meta-qualifier:value" strings.
-    def self.hash_from_vcard_lines(vcard_lines)
+    def hash_from_vcard_lines(vcard_lines)
       vcard_lines.reduce({}) do |vcard_hash, vcard_line|
         if matcher = vcard_line.match(/^([^;]+?)(;[^:]*?)?:(.*)$/)
           _, key, qualifier, value = *matcher

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -20,8 +20,8 @@ class Source::Parser::Ical < Source::Parser
   end
 
   def to_events
-    return false unless calendars
-    events = calendars.flat_map(&:events).reject(&:old?).map(&:to_event).each do |event|
+    return false unless vcalendars
+    events = vcalendars.flat_map(&:vevents).reject(&:old?).map(&:to_event).each do |event|
       event.source = source
     end
     dedup(events)
@@ -29,8 +29,8 @@ class Source::Parser::Ical < Source::Parser
 
   private
 
-  def calendars
-    @calendars ||= VCalendar.parse(content)
+  def vcalendars
+    @vcalendars ||= VCalendar.parse(content)
   end
 
   def content
@@ -58,15 +58,15 @@ class Source::Parser::Ical < Source::Parser
       raise # Unknown error, reraise
     end
 
-    def events
+    def vevents
       calendar.events.map do |component|
-        VEvent.new(component, venues)
+        VEvent.new(component, vvenues)
       end
     end
 
     VENUE_CONTENT_RE = /^BEGIN:VVENUE$.*?^END:VVENUE$/m
 
-    def venues
+    def vvenues
       calendar.to_s.scan(VENUE_CONTENT_RE).map do |venue_content|
         VVenue.new(venue_content)
       end

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -81,10 +81,13 @@ class Source::Parser::Ical < Source::Parser
 
     private
 
+    def venue_uid
+      component.location_property.params["VVENUE"]
+    end
+
     def vvenue
       venues = calendar.venues
       # finding the event venue id - VVENUE=V0-001-001423875-1@eventful.com
-      venue_uid = component.location_property.params["VVENUE"]
       # finding in the venues array an item matching the uid
       venue_uid ? venues.find{|venue| venue.match(/^UID:#{venue_uid}$/m)} : nil
     rescue => exception

--- a/app/models/calagator/source/parser/ical.rb
+++ b/app/models/calagator/source/parser/ical.rb
@@ -59,8 +59,12 @@ class Source::Parser::Ical < Source::Parser
     event_or_duplicate(event)
   end
 
-  class EventParser
+  class EventParser < Struct.new(:component, :source)
     def self.parse(component, source)
+      new(component, source).parse
+    end
+
+    def parse
       Event.new({
         source:      source,
         title:       component.summary,
@@ -71,8 +75,10 @@ class Source::Parser::Ical < Source::Parser
       })
     end
 
+    private
+
     # Helper to set the start and end dates correctly depending on whether it's a floating or fixed timezone
-    def self.normalized_start_time(component)
+    def normalized_start_time(component)
       if component.dtstart_property.tzid
         component.dtstart
       else
@@ -81,7 +87,7 @@ class Source::Parser::Ical < Source::Parser
     end
 
     # Helper to set the start and end dates correctly depending on whether it's a floating or fixed timezone
-    def self.normalized_end_time(component)
+    def normalized_end_time(component)
       if component.dtstart_property.tzid
         component.dtend
       elsif component.dtend_property

--- a/app/models/calagator/source/parser/plancast.rb
+++ b/app/models/calagator/source/parser/plancast.rb
@@ -7,7 +7,7 @@ class Source::Parser::Plancast < Source::Parser
   def to_events
     return unless data = get_data
     event = Event.new({
-      source:      opts[:source],
+      source:      source,
       title:       data['what'],
       description: data['description'],
 
@@ -27,7 +27,7 @@ class Source::Parser::Plancast < Source::Parser
   private
 
   def get_data
-    to_events_api_helper(opts[:url]) do |event_id|
+    to_events_api_helper(url) do |event_id|
       [
         'http://api.plancast.com/02/plans/show.json',
         {
@@ -42,7 +42,7 @@ class Source::Parser::Plancast < Source::Parser
     value = "" if value.nil?
     if value.present?
       venue = Venue.new({
-        source: opts[:source],
+        source: source,
         title: value['name'],
         address: value['address'],
         tag_list: "plancast:place=#{value['id']}",

--- a/lib/calagator/vcalendar.rb
+++ b/lib/calagator/vcalendar.rb
@@ -1,0 +1,113 @@
+require "ri_cal"
+
+module Calagator
+  class VCalendar < Struct.new(:ri_cal_calendar)
+    def self.parse(raw_ical)
+      raw_ical.gsub! /\r\n/, "\n" # normalize line endings
+      raw_ical.gsub! /;TZID=GMT:(.*)/, ':\1Z' # normalize timezones
+
+      RiCal.parse_string(raw_ical).map do |ri_cal_calendar|
+        VCalendar.new(ri_cal_calendar)
+      end
+
+    rescue Exception => exception
+      return false if exception.message =~ /Invalid icalendar file/ # Invalid data, give up.
+      raise # Unknown error, reraise
+    end
+
+    def vevents
+      ri_cal_calendar.events.map do |ri_cal_event|
+        VEvent.new(ri_cal_event, vvenues)
+      end
+    end
+
+    VENUE_CONTENT_RE = /^BEGIN:VVENUE$.*?^END:VVENUE$/m
+
+    def vvenues
+      ri_cal_calendar.to_s.scan(VENUE_CONTENT_RE).map do |raw_ical_venue|
+        VVenue.new(raw_ical_venue)
+      end
+    end
+  end
+
+  class VEvent < Struct.new(:ri_cal_event, :vvenues)
+    def old?
+      cutoff = Time.now.yesterday
+      (ri_cal_event.dtend || ri_cal_event.dtstart).to_time < cutoff
+    end
+
+    delegate :location, :summary, :description, :url, to: :ri_cal_event
+
+    # translate the start and end dates correctly depending on whether it's a floating or fixed timezone
+
+    def start_time
+      if ri_cal_event.dtstart_property.tzid
+        ri_cal_event.dtstart
+      else
+        Time.zone.parse(ri_cal_event.dtstart_property.value)
+      end
+    end
+
+    def end_time
+      if ri_cal_event.dtstart_property.tzid
+        ri_cal_event.dtend
+      elsif ri_cal_event.dtend_property
+        Time.zone.parse(ri_cal_event.dtend_property.value)
+      elsif ri_cal_event.duration
+        ri_cal_event.duration_property.add_to_date_time_value(start_time)
+      else
+        start_time
+      end
+    end
+
+    def vvenue
+      vvenues.find { |venue| venue.uid == venue_uid } if venue_uid
+    end
+
+    private
+
+    def venue_uid
+      ri_cal_event.location_property.try(:params).try(:[], "VVENUE")
+    end
+  end
+
+  class VVenue < Struct.new(:raw_ical_venue)
+    def uid
+      raw_ical_venue.match(/^UID:(?<uid>.+)$/)[:uid]
+    end
+
+    def method_missing(method, *args, &block)
+      vcard_hash_key = method.to_s.upcase
+      return vcard_hash[vcard_hash_key] if vcard_hash.has_key?(vcard_hash_key)
+      super
+    end
+
+    def respond_to?(method, include_private = false)
+      vcard_hash_key = method.to_s.upcase
+      vcard_hash.has_key?(vcard_hash_key) || super
+    end
+
+    private
+
+    def vcard_hash
+      # Only use first vcard of a VVENUE
+      vcard = RiCal.parse_string(raw_ical_venue).first
+
+      # Extract all properties into an array of "KEY;meta-qualifier:value" strings
+      vcard_lines = vcard.export_properties_to(StringIO.new(''))
+
+      hash_from_vcard_lines(vcard_lines)
+    end
+
+    VCARD_LINES_RE = /^(?<key>[^;]+?)(?<qualifier>;[^:]*?)?:(?<value>.*)$/
+
+    def hash_from_vcard_lines(vcard_lines)
+      vcard_lines.reduce({}) do |vcard_hash, vcard_line|
+        vcard_line.match(VCARD_LINES_RE) do |match|
+          vcard_hash[match[:key]] ||= match[:value]
+        end
+        vcard_hash
+      end
+    end
+  end
+end

--- a/lib/calagator/vcalendar.rb
+++ b/lib/calagator/vcalendar.rb
@@ -87,7 +87,20 @@ module Calagator
       vcard_hash.has_key?(vcard_hash_key) || super
     end
 
+    def latitude
+      geo_latlng.first
+    end
+
+    def longitude
+      geo_latlng.last
+    end
+
     private
+
+    def geo_latlng
+      return [] unless geo
+      geo.split(/;/).map(&:to_f)
+    end
 
     def vcard_hash
       # Only use first vcard of a VVENUE

--- a/spec/controllers/calagator/sources_controller_spec.rb
+++ b/spec/controllers/calagator/sources_controller_spec.rb
@@ -20,6 +20,7 @@ describe SourcesController, :type => :controller do
         :venue => @venue,
         :start_time => Time.now+1.week,
         :end_time => nil,
+        :old? => false,
         :duplicate_of_id => nil)
 
       @source = Source.new(:url => "http://my.url/")

--- a/spec/lib/calagator/vcalendar_spec.rb
+++ b/spec/lib/calagator/vcalendar_spec.rb
@@ -1,13 +1,11 @@
 require 'spec_helper'
+require 'calagator/vcalendar'
 
 module Calagator
 
-describe Source::Parser::Ical::VenueParser, "when parsing VVENUE", :type => :model do
-   subject do
-     described_class.new(vvenue).to_venue
-   end
-
-   let(:vvenue) { Source::Parser::Ical::VVenue.new(<<-ICAL) }
+describe VVenue, "when parsing VVENUE", :type => :model do
+  subject do
+    described_class.new(<<-ICAL)
 BEGIN:VVENUE
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.
   html
@@ -26,37 +24,30 @@ URL;X-LABEL=Venue Info:http://eventful.com/V0-001-001423875-1
 CATEGORIES:apple applecom appleinc technology
 END:VVENUE
 ICAL
-
-  it "should have a street_address" do
-    expect(subject.street_address).not_to be_nil
   end
 
   it "should have the adress as is" do
-    expect(subject.street_address).to eq '700 Southwest Fifth Avenue Suite #1035'
-  end
-
-  it "should have a locality" do
-    expect(subject.locality).not_to be_nil
+    expect(subject.address).to eq '700 Southwest Fifth Avenue Suite #1035'
   end
 
   it "should have the locality as is" do
-    expect(subject.locality).to eq 'Portland'
+    expect(subject.city).to eq 'Portland'
   end
 
   it "should find a property set by its key" do
-    expect(vvenue.name).to eq 'Apple Store Pioneer Place'
+    expect(subject.name).to eq 'Apple Store Pioneer Place'
   end
 
   it "should find a property set by its key and meta-qualifier by its key when one wasn't specified" do
-    expect(vvenue.url).to eq 'http://eventful.com/V0-001-001423875-1'
+    expect(subject.url).to eq 'http://eventful.com/V0-001-001423875-1'
   end
 
   it "should find a property set by its key and multiple meta-qualifiers by its key when one wasn't specified" do
-    expect(vvenue.country).to eq 'United States'
+    expect(subject.country).to eq 'United States'
   end
 
   it "should find a property set by its key and meta-qualifier with odd characters by its key when one wasn't specified" do
-    expect(vvenue.region).to eq 'Oregon'
+    expect(subject.region).to eq 'Oregon'
   end
 end
 

--- a/spec/lib/calagator/vcalendar_spec.rb
+++ b/spec/lib/calagator/vcalendar_spec.rb
@@ -26,7 +26,7 @@ END:VVENUE
 ICAL
   end
 
-  it "should have the adress as is" do
+  it "should have the address as-is" do
     expect(subject.address).to eq '700 Southwest Fifth Avenue Suite #1035'
   end
 
@@ -48,6 +48,18 @@ ICAL
 
   it "should find a property set by its key and meta-qualifier with odd characters by its key when one wasn't specified" do
     expect(subject.region).to eq 'Oregon'
+  end
+
+  it "responds to fields that it has" do
+    expect(subject).to respond_to(:address)
+  end
+
+  it "does not respond to fields that it does not have" do
+    expect(subject).to_not respond_to(:omg)
+  end
+
+  it "raises an exception if field is not there" do
+    expect{subject.omg}.to raise_exception(NoMethodError)
   end
 end
 

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -103,7 +103,7 @@ describe Event, :type => :model do
       @basic_event = Event.new(
         :title => 'Web 2.0 Conference',
         :url => 'http://www.web2con.com/',
-        :start_time => Time.zone.parse('2007-10-05'),
+        :start_time => 1.day.from_now,
         :end_time => nil,
         :venue => @basic_venue)
     end
@@ -113,7 +113,7 @@ describe Event, :type => :model do
       actual_ical = Event::IcalRenderer.render(@basic_event)
       stub_request(:get, url).to_return(body: actual_ical)
 
-      events = Source::Parser.to_events(url: url, skip_old: false)
+      events = Source::Parser.to_events(url: url)
 
       expect(events.size).to eq 1
       event = events.first
@@ -131,7 +131,7 @@ describe Event, :type => :model do
       url = "http://foo.bar/"
       stub_request(:get, url).to_return(body: actual_ical)
 
-      events = Source::Parser.to_events(url: url, skip_old: false)
+      events = Source::Parser.to_events(url: url)
 
       expect(events.size).to eq 1
       event = events.first

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -42,40 +42,21 @@ ICAL
   it "should have the locality as is" do
     expect(subject.locality).to eq 'Portland'
   end
-end
-
-describe Source::Parser::Ical::VVenue, "when parsing VCARD lines", :type => :model do
-   before(:each) do
-     # Note that each line here represents a single, complete property definition -- this method doesn't do any magical unwrapping of text.
-     @vcard_hash = described_class.new.send :hash_from_vcard_lines, %(
-X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.html
-UID:V0-001-001423875-1@eventful.com
-NAME:Apple Store Pioneer Place
-DESCRIPTION:(503) 222-3002 Driving Directions & Map  Store Hours:  Mon - Fri: 9:30 a.m. to 9:00 p.m. Sat: 9:30 a.m. to 8:00 p.m. Sun: 11:00 a.m. to 6:00 p.m.
-ADDRESS:700 Southwest Fifth Avenue Suite; #1035
-CITY:Portland
-REGION;KMeta=none&bizzare:Oregon
-COUNTRY;;;ABBREV=USA:United States
-POSTALCODE:97204
-GEO:45.518798;-122.677583
-URL;X-LABEL=Venue Info:http://eventful.com/V0-001-001423875-1
-CATEGORIES:apple applecom appleinc technology).split("\n")
-  end
 
   it "should find a property set by its key" do
-    expect(@vcard_hash['NAME']).to eq 'Apple Store Pioneer Place'
+    expect(vvenue.vcard_hash['NAME']).to eq 'Apple Store Pioneer Place'
   end
 
   it "should find a property set by its key and meta-qualifier by its key when one wasn't specified" do
-    expect(@vcard_hash['URL']).to eq 'http://eventful.com/V0-001-001423875-1'
+    expect(vvenue.vcard_hash['URL']).to eq 'http://eventful.com/V0-001-001423875-1'
   end
 
   it "should find a property set by its key and multiple meta-qualifiers by its key when one wasn't specified" do
-    expect(@vcard_hash['COUNTRY']).to eq 'United States'
+    expect(vvenue.vcard_hash['COUNTRY']).to eq 'United States'
   end
 
   it "should find a property set by its key and meta-qualifier with odd characters by its key when one wasn't specified" do
-    expect(@vcard_hash['REGION']).to eq 'Oregon'
+    expect(vvenue.vcard_hash['REGION']).to eq 'Oregon'
   end
 end
 

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 module Calagator
 
-describe Calagator::Source::Parser::Ical::VenueParser, "when parsing VVENUE", :type => :model do
+describe Source::Parser::Ical::VenueParser, "when parsing VVENUE", :type => :model do
    subject do
      described_class.new(vvenue).to_venue
    end
 
-   let(:vvenue) { double(content: <<-ICAL) }
+   let(:vvenue) { Source::Parser::Ical::VVenue.new(<<-ICAL) }
 BEGIN:VVENUE
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.
   html
@@ -44,7 +44,7 @@ ICAL
   end
 end
 
-describe Source::Parser::Ical::VenueParser, "when parsing VCARD lines", :type => :model do
+describe Source::Parser::Ical::VVenue, "when parsing VCARD lines", :type => :model do
    before(:each) do
      # Note that each line here represents a single, complete property definition -- this method doesn't do any magical unwrapping of text.
      @vcard_hash = described_class.new.send :hash_from_vcard_lines, %(

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -29,7 +29,7 @@ END:VVENUE))
   end
 
   it "should have the adress as is" do
-    @venue.street_address == '700 Southwest Fifth Avenue Suite #1035'
+    expect(@venue.street_address).to eq '700 Southwest Fifth Avenue Suite #1035'
   end
 
   it "should have a locality" do
@@ -37,7 +37,7 @@ END:VVENUE))
   end
 
   it "should have the locality as is" do
-    @venue.locality == 'Portland'
+    expect(@venue.locality).to eq 'Portland'
   end
 end
 
@@ -72,19 +72,19 @@ CATEGORIES:apple applecom appleinc technology).split("\n"))
   end
 
   it "should find a property set by its key and multiple meta-qualifier by" do
-    @vcard_hash['COUNTRY;;;ABBREV=USA'] == 'United States'
+    expect(@vcard_hash['COUNTRY;;;ABBREV=USA']).to eq 'United States'
   end
 
   it "should find a property set by its key and multiple meta-qualifiers by its key when one wasn't specified" do
-    @vcard_hash['COUNTRY'] == 'United States'
+    expect(@vcard_hash['COUNTRY']).to eq 'United States'
   end
 
   it "should find a property set by its key and meta-qualifier with odd characters" do
-    @vcard_hash['REGION;KMeta=none&bizzare'] == 'Oregon'
+    expect(@vcard_hash['REGION;KMeta=none&bizzare']).to eq 'Oregon'
   end
 
   it "should find a property set by its key and meta-qualifier with odd characters by its key when one wasn't specified" do
-    @vcard_hash['REGION'] == 'Oregon'
+    expect(@vcard_hash['REGION']).to eq 'Oregon'
   end
 end
 

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -44,19 +44,19 @@ ICAL
   end
 
   it "should find a property set by its key" do
-    expect(vvenue.vcard_hash['NAME']).to eq 'Apple Store Pioneer Place'
+    expect(vvenue.name).to eq 'Apple Store Pioneer Place'
   end
 
   it "should find a property set by its key and meta-qualifier by its key when one wasn't specified" do
-    expect(vvenue.vcard_hash['URL']).to eq 'http://eventful.com/V0-001-001423875-1'
+    expect(vvenue.url).to eq 'http://eventful.com/V0-001-001423875-1'
   end
 
   it "should find a property set by its key and multiple meta-qualifiers by its key when one wasn't specified" do
-    expect(vvenue.vcard_hash['COUNTRY']).to eq 'United States'
+    expect(vvenue.country).to eq 'United States'
   end
 
   it "should find a property set by its key and meta-qualifier with odd characters by its key when one wasn't specified" do
-    expect(vvenue.vcard_hash['REGION']).to eq 'Oregon'
+    expect(vvenue.region).to eq 'Oregon'
   end
 end
 

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 module Calagator
 
 describe Calagator::Source::Parser::Ical::VenueParser, "when parsing VVENUE", :type => :model do
-   before(:each) do
-     @venue = described_class.parse(%(
+   subject do
+     described_class.new(<<-ICAL).to_venue
 BEGIN:VVENUE
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.
   html
@@ -21,23 +21,24 @@ POSTALCODE:97204
 GEO:45.518798;-122.677583
 URL;X-LABEL=Venue Info:http://eventful.com/V0-001-001423875-1
 CATEGORIES:apple applecom appleinc technology
-END:VVENUE))
+END:VVENUE
+ICAL
   end
 
   it "should have a street_address" do
-    expect(@venue.street_address).not_to be_nil
+    expect(subject.street_address).not_to be_nil
   end
 
   it "should have the adress as is" do
-    expect(@venue.street_address).to eq '700 Southwest Fifth Avenue Suite #1035'
+    expect(subject.street_address).to eq '700 Southwest Fifth Avenue Suite #1035'
   end
 
   it "should have a locality" do
-    expect(@venue.locality).not_to be_nil
+    expect(subject.locality).not_to be_nil
   end
 
   it "should have the locality as is" do
-    expect(@venue.locality).to eq 'Portland'
+    expect(subject.locality).to eq 'Portland'
   end
 end
 

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 module Calagator
 
-describe Calagator::Source::Parser::Ical, "when parsing VVENUE", :type => :model do
+describe Calagator::Source::Parser::Ical::VenueParser, "when parsing VVENUE", :type => :model do
    before(:each) do
-     @venue = Source::Parser::Ical.new.send(:to_venue, %(
+     @venue = described_class.parse(%(
 BEGIN:VVENUE
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.
   html
@@ -41,10 +41,10 @@ END:VVENUE))
   end
 end
 
-describe Source::Parser::Ical, "when parsing VCARD lines", :type => :model do
+describe Source::Parser::Ical::VenueParser, "when parsing VCARD lines", :type => :model do
    before(:each) do
      # Note that each line here represents a single, complete property definition -- this method doesn't do any magical unwrapping of text.
-     @vcard_hash = Source::Parser::Ical.new.send(:hash_from_vcard_lines, %(
+     @vcard_hash = described_class.hash_from_vcard_lines(%(
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.html
 UID:V0-001-001423875-1@eventful.com
 NAME:Apple Store Pioneer Place

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -44,7 +44,7 @@ end
 describe Source::Parser::Ical::VenueParser, "when parsing VCARD lines", :type => :model do
    before(:each) do
      # Note that each line here represents a single, complete property definition -- this method doesn't do any magical unwrapping of text.
-     @vcard_hash = described_class.hash_from_vcard_lines(%(
+     @vcard_hash = described_class.new.send :hash_from_vcard_lines, %(
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.html
 UID:V0-001-001423875-1@eventful.com
 NAME:Apple Store Pioneer Place
@@ -56,7 +56,7 @@ COUNTRY;;;ABBREV=USA:United States
 POSTALCODE:97204
 GEO:45.518798;-122.677583
 URL;X-LABEL=Venue Info:http://eventful.com/V0-001-001423875-1
-CATEGORIES:apple applecom appleinc technology).split("\n"))
+CATEGORIES:apple applecom appleinc technology).split("\n")
   end
 
   it "should find a property set by its key" do

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -4,7 +4,10 @@ module Calagator
 
 describe Calagator::Source::Parser::Ical::VenueParser, "when parsing VVENUE", :type => :model do
    subject do
-     described_class.new(<<-ICAL).to_venue
+     described_class.new(vvenue).to_venue
+   end
+
+   let(:vvenue) { double(content: <<-ICAL) }
 BEGIN:VVENUE
 X-VVENUE-INFO:http://evdb.com/docs/ical-venue/draft-norris-ical-venue.
   html
@@ -23,7 +26,6 @@ URL;X-LABEL=Venue Info:http://eventful.com/V0-001-001423875-1
 CATEGORIES:apple applecom appleinc technology
 END:VVENUE
 ICAL
-  end
 
   it "should have a street_address" do
     expect(subject.street_address).not_to be_nil

--- a/spec/models/calagator/source/parser_ical_non_standard_spec.rb
+++ b/spec/models/calagator/source/parser_ical_non_standard_spec.rb
@@ -63,24 +63,12 @@ CATEGORIES:apple applecom appleinc technology).split("\n")
     expect(@vcard_hash['NAME']).to eq 'Apple Store Pioneer Place'
   end
 
-  it "should find a property set by its key and meta-qualifier" do
-    expect(@vcard_hash['URL;X-LABEL=Venue Info']).to eq 'http://eventful.com/V0-001-001423875-1'
-  end
-
   it "should find a property set by its key and meta-qualifier by its key when one wasn't specified" do
     expect(@vcard_hash['URL']).to eq 'http://eventful.com/V0-001-001423875-1'
   end
 
-  it "should find a property set by its key and multiple meta-qualifier by" do
-    expect(@vcard_hash['COUNTRY;;;ABBREV=USA']).to eq 'United States'
-  end
-
   it "should find a property set by its key and multiple meta-qualifiers by its key when one wasn't specified" do
     expect(@vcard_hash['COUNTRY']).to eq 'United States'
-  end
-
-  it "should find a property set by its key and meta-qualifier with odd characters" do
-    expect(@vcard_hash['REGION;KMeta=none&bizzare']).to eq 'Oregon'
   end
 
   it "should find a property set by its key and meta-qualifier with odd characters by its key when one wasn't specified" do

--- a/spec/models/calagator/source/parser_ical_spec.rb
+++ b/spec/models/calagator/source/parser_ical_spec.rb
@@ -1,229 +1,226 @@
 require 'spec_helper'
 
-def events_from_ical_at(filename)
-  url = "http://foo.bar/"
-  source = Calagator::Source.new(:title => "Calendar event feed", :url => url)
-  stub_request(:get, url).to_return(body: read_sample(filename))
-  return source.to_events(:skip_old => false)
-end
-
 module Calagator
-
-describe Source::Parser::Ical, "in general", :type => :model do
-  it "should read http URLs as-is" do
-    url = "http://foo.bar/"
-    stub_request(:get, url).to_return(body: "42")
-    expect(Source::Parser::Ical.read_url(url)).to eq "42"
-  end
-
-  it "should read webcal URLs as http" do
-    webcal_url = "webcal://foo.bar/"
-    http_url   = "http://foo.bar/"
-    stub_request(:get, http_url).to_return(body: "42")
-    expect(Source::Parser::Ical.read_url(webcal_url)).to eq "42"
-  end
-end
-
-describe Source::Parser::Ical, "when parsing events and their venues", :type => :model do
-
-  before(:each) do
-    url = "http://foo.bar/"
-    stub_request(:get, url).to_return(body: read_sample('ical_upcoming_many.ics'))
-    @events = Source::Parser.to_events(url: url, skip_old: false)
-  end
-
-   it "venues should be" do
-    @events.each do |event|
-      expect(event.venue).not_to be_nil
+  describe Source::Parser::Ical, type: :model do
+    def events_from_ical_at(filename)
+      url = "http://foo.bar/"
+      source = Calagator::Source.new(:title => "Calendar event feed", :url => url)
+      stub_request(:get, url).to_return(body: read_sample(filename))
+      return source.to_events(:skip_old => false)
     end
-  end
 
-end
-
-describe Source::Parser::Ical, "when parsing multiple items in an Eventful feed", :type => :model do
-  before(:each) do
-    url = "http://foo.bar/"
-    stub_request(:get, url).to_return(body: read_sample('ical_eventful_many.ics'))
-    @events = Source::Parser.to_events(url: url, skip_old: false)
-  end
-
-  it "should find multiple events" do
-    expect(@events.size).to eq 15
-  end
-
-  it "should find venues for events" do
-    @events.each do |event|
-      expect(event.venue.title).not_to be_nil
-    end
-  end
-
-  it "should match each event with its venue" do
-    event_titles_and_street_addresses = [
-      ["iMovie and iDVD Workshop", "7293 SW Bridgeport Road"],
-      ["Portland Macintosh Users Group (PMUG)", "Jean Vollum Natural Capital Center"],
-      ["Morning Meetings: IT", "622 SE Grand Avenue"]
-    ]
-
-    # Make sure each of the above events has the expected street address
-    event_titles_and_street_addresses.each do |event_title, street_address|
-      expect(@events.find { |event|
-        event.title == event_title && event.venue.street_address == street_address
-        }).not_to be_nil
+    describe "in general" do
+      it "should read http URLs as-is" do
+        url = "http://foo.bar/"
+        stub_request(:get, url).to_return(body: "42")
+        expect(Source::Parser::Ical.read_url(url)).to eq "42"
       end
-  end
-end
 
-describe Source::Parser::Ical, "with iCalendar events", :type => :model do
+      it "should read webcal URLs as http" do
+        webcal_url = "webcal://foo.bar/"
+        http_url   = "http://foo.bar/"
+        stub_request(:get, http_url).to_return(body: "42")
+        expect(Source::Parser::Ical.read_url(webcal_url)).to eq "42"
+      end
+    end
 
-  it "should parse Apple iCalendar v3 format" do
-    events = events_from_ical_at('ical_apple_v3.ics')
+    describe "when parsing events and their venues" do
+      before(:each) do
+        url = "http://foo.bar/"
+        stub_request(:get, url).to_return(body: read_sample('ical_upcoming_many.ics'))
+        @events = Source::Parser.to_events(url: url, skip_old: false)
+      end
 
-    expect(events.size).to eq 1
-    event = events.first
-    expect(event.title).to eq "Coffee with Jason"
-    expect(event.start_time).to eq Time.zone.parse('2010-04-08 00:00:00 PDT -07:00')
-    expect(event.end_time).to eq Time.zone.parse('2010-04-08 01:00:00 PDT -07:00')
-    expect(event.venue).to be_nil
-  end
+      it "venues should be" do
+        @events.each do |event|
+          expect(event.venue).not_to be_nil
+        end
+      end
 
-  it "should parse basic iCalendar format" do
-    events = events_from_ical_at('ical_basic.ics')
+    end
 
-    expect(events.size).to eq 1
-    event = events.first
-    expect(event.title).to be_blank
-    expect(event.start_time).to eq Time.zone.parse('Wed Jan 17 00:00:00 2007')
-    expect(event.venue).to be_nil
-  end
+    describe "when parsing multiple items in an Eventful feed" do
+      before(:each) do
+        url = "http://foo.bar/"
+        stub_request(:get, url).to_return(body: read_sample('ical_eventful_many.ics'))
+        @events = Source::Parser.to_events(url: url, skip_old: false)
+      end
 
-  it "should parse basic iCalendar format with a duration and set the correct end time" do
-    events = events_from_ical_at('ical_basic_with_duration.ics')
+      it "should find multiple events" do
+        expect(@events.size).to eq 15
+      end
 
-    expect(events.size).to eq 1
-    event = events.first
-    expect(event.title).to be_blank
-    expect(event.start_time).to eq Time.zone.parse('2010-04-08 00:00:00')
-    expect(event.end_time).to eq Time.zone.parse('2010-04-08 01:00:00')
-    expect(event.venue).to be_nil
-  end
+      it "should find venues for events" do
+        @events.each do |event|
+          expect(event.venue.title).not_to be_nil
+        end
+      end
 
-  it "should parse Google iCalendar feed with multiple events" do
-    events = events_from_ical_at('ical_google.ics')
-    # TODO add specs for venues/locations
+      it "should match each event with its venue" do
+        event_titles_and_street_addresses = [
+          ["iMovie and iDVD Workshop", "7293 SW Bridgeport Road"],
+          ["Portland Macintosh Users Group (PMUG)", "Jean Vollum Natural Capital Center"],
+          ["Morning Meetings: IT", "622 SE Grand Avenue"]
+        ]
 
-    expect(events.size).to eq 47
+        # Make sure each of the above events has the expected street address
+        event_titles_and_street_addresses.each do |event_title, street_address|
+          expect(@events.find { |event|
+            event.title == event_title && event.venue.street_address == street_address
+          }).not_to be_nil
+        end
+      end
+    end
 
-    event = events.first
-    expect(event.title).to eq "XPDX (eXtreme Programming) at CubeSpace"
-    expect(event.description).to be_blank
-    expect(event.start_time).to eq Time.parse("2007-10-24 18:30:00 PDT")
-    expect(event.end_time).to eq Time.parse("2007-10-24 19:30:00 PDT")
+    describe "with iCalendar events" do
+      it "should parse Apple iCalendar v3 format" do
+        events = events_from_ical_at('ical_apple_v3.ics')
 
-    event = events[17]
-    expect(event.title).to eq "Code Sprint/Coding Dojo at CubeSpace"
-    expect(event.description).to be_blank
-    expect(event.start_time).to eq Time.parse("2007-10-17 19:00:00 PDT")
-    expect(event.end_time).to eq Time.parse("2007-10-17 21:00:00 PDT")
+        expect(events.size).to eq 1
+        event = events.first
+        expect(event.title).to eq "Coffee with Jason"
+        expect(event.start_time).to eq Time.zone.parse('2010-04-08 00:00:00 PDT -07:00')
+        expect(event.end_time).to eq Time.zone.parse('2010-04-08 01:00:00 PDT -07:00')
+        expect(event.venue).to be_nil
+      end
 
-    event = events.last
-    expect(event.title).to eq "Adobe Developer User Group"
-    expect(event.description).to eq "http://pdxria.com/"
-    expect(event.start_time).to eq Time.parse("2007-01-16 17:30:00 PST")
-    expect(event.end_time).to eq Time.parse("2007-01-16 18:30:00 PST")
-  end
+      it "should parse basic iCalendar format" do
+        events = events_from_ical_at('ical_basic.ics')
 
-  it "should parse non-Vcard locations" do
-    events = events_from_ical_at('ical_google.ics')
-    expect(events.first.venue.title).to eq 'CubeSpace'
-  end
+        expect(events.size).to eq 1
+        event = events.first
+        expect(event.title).to be_blank
+        expect(event.start_time).to eq Time.zone.parse('Wed Jan 17 00:00:00 2007')
+        expect(event.venue).to be_nil
+      end
 
-  it "should parse a calendar file with multiple calendars" do
-    events = events_from_ical_at('ical_multiple_calendars.ics')
-    expect(events.size).to eq 3
-    expect(events.map(&:title)).to eq ["Coffee with Jason", "Coffee with Mike", "Coffee with Kim"]
-  end
+      it "should parse basic iCalendar format with a duration and set the correct end time" do
+        events = events_from_ical_at('ical_basic_with_duration.ics')
 
-  it "should not swallow errors" do
-    expect(RiCal).to receive(:parse_string).and_raise(TypeError)
-    expect { events_from_ical_at('ical_multiple_calendars.ics') }.to raise_error(TypeError)
-  end
-end
+        expect(events.size).to eq 1
+        event = events.first
+        expect(event.title).to be_blank
+        expect(event.start_time).to eq Time.zone.parse('2010-04-08 00:00:00')
+        expect(event.end_time).to eq Time.zone.parse('2010-04-08 01:00:00')
+        expect(event.venue).to be_nil
+      end
 
-describe Source::Parser::Ical, "when importing events with non-local times", :type => :model do
+      it "should parse Google iCalendar feed with multiple events" do
+        events = events_from_ical_at('ical_google.ics')
+        # TODO add specs for venues/locations
 
-  it "should store time ending in Z as UTC" do
-    url = "http://foo.bar/"
-    stub_request(:get, url).to_return(body: read_sample('ical_z.ics'))
-    @source = Source.new(:title => "Non-local time", :url => url)
-    events = @source.create_events!(:skip_old => false)
-    event = events.first
+        expect(events.size).to eq 47
 
-    expect(event.start_time).to eq Time.parse('Thu Jul 01 08:00:00 +0000 2010')
-    expect(event.end_time).to eq Time.parse('Thu Jul 01 09:00:00 +0000 2010')
+        event = events.first
+        expect(event.title).to eq "XPDX (eXtreme Programming) at CubeSpace"
+        expect(event.description).to be_blank
+        expect(event.start_time).to eq Time.parse("2007-10-24 18:30:00 PDT")
+        expect(event.end_time).to eq Time.parse("2007-10-24 19:30:00 PDT")
 
-    # time should be the same after saving event to, and getting it from, database
-    event.save
-    event.reload
-    expect(event.start_time).to eq Time.parse('Thu Jul 01 08:00:00 +0000 2010')
-    expect(event.end_time).to eq Time.parse('Thu Jul 01 09:00:00 +0000 2010')
-  end
+        event = events[17]
+        expect(event.title).to eq "Code Sprint/Coding Dojo at CubeSpace"
+        expect(event.description).to be_blank
+        expect(event.start_time).to eq Time.parse("2007-10-17 19:00:00 PDT")
+        expect(event.end_time).to eq Time.parse("2007-10-17 21:00:00 PDT")
 
-  it "should store time with TZID=GMT in UTC" do
-    events = events_from_ical_at('ical_gmt.ics')
-    expect(events.size).to eq 1
-    event = events.first
-    expect(event.start_time).to eq Time.parse('Fri May 07 08:00:00 +0000 2020')
-    expect(event.end_time).to eq Time.parse('Fri May 07 09:00:00 +0000 2020')
-  end
-end
+        event = events.last
+        expect(event.title).to eq "Adobe Developer User Group"
+        expect(event.description).to eq "http://pdxria.com/"
+        expect(event.start_time).to eq Time.parse("2007-01-16 17:30:00 PST")
+        expect(event.end_time).to eq Time.parse("2007-01-16 18:30:00 PST")
+      end
 
-describe Source::Parser::Ical, "munge_gmt_dates", :type => :model do
-  it "should return unexpected-format strings unmodified" do
-    munged = Source::Parser::Ical.new.send(:munge_gmt_dates, 'justin bieber on a train')
-    expect(munged).to eq 'justin bieber on a train'
-  end
+      it "should parse non-Vcard locations" do
+        events = events_from_ical_at('ical_google.ics')
+        expect(events.first.venue.title).to eq 'CubeSpace'
+      end
 
-  it "should return GMT-less ical strings unmodified" do
-    icard = %{
+      it "should parse a calendar file with multiple calendars" do
+        events = events_from_ical_at('ical_multiple_calendars.ics')
+        expect(events.size).to eq 3
+        expect(events.map(&:title)).to eq ["Coffee with Jason", "Coffee with Mike", "Coffee with Kim"]
+      end
+
+      it "should not swallow errors" do
+        expect(RiCal).to receive(:parse_string).and_raise(TypeError)
+        expect { events_from_ical_at('ical_multiple_calendars.ics') }.to raise_error(TypeError)
+      end
+    end
+
+    describe "when importing events with non-local times" do
+      it "should store time ending in Z as UTC" do
+        url = "http://foo.bar/"
+        stub_request(:get, url).to_return(body: read_sample('ical_z.ics'))
+        @source = Source.new(:title => "Non-local time", :url => url)
+        events = @source.create_events!(:skip_old => false)
+        event = events.first
+
+        expect(event.start_time).to eq Time.parse('Thu Jul 01 08:00:00 +0000 2010')
+        expect(event.end_time).to eq Time.parse('Thu Jul 01 09:00:00 +0000 2010')
+
+        # time should be the same after saving event to, and getting it from, database
+        event.save
+        event.reload
+        expect(event.start_time).to eq Time.parse('Thu Jul 01 08:00:00 +0000 2010')
+        expect(event.end_time).to eq Time.parse('Thu Jul 01 09:00:00 +0000 2010')
+      end
+
+      it "should store time with TZID=GMT in UTC" do
+        events = events_from_ical_at('ical_gmt.ics')
+        expect(events.size).to eq 1
+        event = events.first
+        expect(event.start_time).to eq Time.parse('Fri May 07 08:00:00 +0000 2020')
+        expect(event.end_time).to eq Time.parse('Fri May 07 09:00:00 +0000 2020')
+      end
+    end
+
+    describe "munge_gmt_dates" do
+      it "should return unexpected-format strings unmodified" do
+        munged = Source::Parser::Ical.new.send(:munge_gmt_dates, 'justin bieber on a train')
+        expect(munged).to eq 'justin bieber on a train'
+      end
+
+      it "should return GMT-less ical strings unmodified" do
+        icard = %{
 BEGIN:VCALENDAR
 BEGIN:VEVENT
 DTSTART:20200507T080000
 DTEND:20200507T090000
 END:VEVENT
 END:VCALENDAR
-    }
+        }
 
-    expect(Source::Parser::Ical.new.send(:munge_gmt_dates, icard)).to eq icard
-  end
+        expect(Source::Parser::Ical.new.send(:munge_gmt_dates, icard)).to eq icard
+      end
 
-  it "should replace TZID=GMT with a TZID-less UTC time" do
-    icard = %{
+      it "should replace TZID=GMT with a TZID-less UTC time" do
+        icard = %{
 BEGIN:VCALENDAR
 BEGIN:VEVENT
 DTSTART;TZID=GMT:20200507T080000
 DTEND;TZID=GMT:20200507T090000
 END:VEVENT
 END:VCALENDAR
-    }
+        }
 
-    munged = %{
+        munged = %{
 BEGIN:VCALENDAR
 BEGIN:VEVENT
 DTSTART:20200507T080000Z
 DTEND:20200507T090000Z
 END:VEVENT
 END:VCALENDAR
-    }
+        }
 
-    expect(Source::Parser::Ical.new.send(:munge_gmt_dates, icard)).to eq munged
-  end
-end
+        expect(Source::Parser::Ical.new.send(:munge_gmt_dates, icard)).to eq munged
+      end
+    end
 
-describe Source::Parser::Ical, "when skipping old events", :type => :model do
-  before(:each) do
-    url = "http://foo.bar/"
-    stub_request(:get, url).to_return(body:
-%(BEGIN:VCALENDAR
+    describe "when skipping old events" do
+      before(:each) do
+        url = "http://foo.bar/"
+        stub_request(:get, url).to_return(body:
+                                          %(BEGIN:VCALENDAR
 X-WR-CALNAME;VALUE=TEXT:NERV
 VERSION:2.0
 CALSCALE:GREGORIAN
@@ -278,45 +275,45 @@ DTEND:#{(Time.now-1.year).strftime("%Y%m%d")}
 DTSTAMP:040425
 END:VEVENT
 END:VCALENDAR))
-    @source = Source.new(title: "Title", url: url)
-  end
+        @source = Source.new(title: "Title", url: url)
+      end
 
-  # for following specs a 'valid' event does not start after it ends"
-  it "should be able to import all valid events" do
-    events = @source.create_events!(:skip_old => false)
-    expect(events.map(&:title)).to eq [
-      "Past start and no end",
-      "Current start and no end",
-      "Past start and current end",
-      "Current start and current end",
-      "Past start and past end"
-    ]
-  end
+      # for following specs a 'valid' event does not start after it ends"
+      it "should be able to import all valid events" do
+        events = @source.create_events!(:skip_old => false)
+        expect(events.map(&:title)).to eq [
+          "Past start and no end",
+          "Current start and no end",
+          "Past start and current end",
+          "Current start and current end",
+          "Past start and past end"
+        ]
+      end
 
-  it "should be able to skip invalid and old events" do
-    events = @source.create_events!(:skip_old => true)
-    expect(events.map(&:title)).to eq [
-      "Current start and no end",
-      "Past start and current end",
-      "Current start and current end"
-    ]
-  end
-end
+      it "should be able to skip invalid and old events" do
+        events = @source.create_events!(:skip_old => true)
+        expect(events.map(&:title)).to eq [
+          "Current start and no end",
+          "Past start and current end",
+          "Current start and current end"
+        ]
+      end
+    end
 
-describe Source::Parser::Ical, "when parsing an invalid ical", :type => :model do
-  before(:each) do
-    url = "http://foo.bar/"
-    stub_request(:get, url).to_return(body:
-%(BEGIN:VCALENDAR
+    describe "when parsing an invalid ical" do
+      before(:each) do
+        url = "http://foo.bar/"
+        stub_request(:get, url).to_return(body:
+                                          %(BEGIN:VCALENDAR
 BEGIN:VEVENT
 OMGWTFBBQ
 END:VCALENDAR))
-    @source = Source.new(title: "Title", url: url)
-  end
+        @source = Source.new(title: "Title", url: url)
+      end
 
-  it "should return no events" do
-    @source.create_events!.should == []
+      it "should return no events" do
+        @source.create_events!.should == []
+      end
+    end
   end
-end
-
 end

--- a/spec/models/calagator/source/parser_ical_spec.rb
+++ b/spec/models/calagator/source/parser_ical_spec.rb
@@ -180,48 +180,6 @@ module Calagator
       end
     end
 
-    describe "munge_gmt_dates" do
-      it "should return unexpected-format strings unmodified" do
-        munged = Source::Parser::Ical.new.send(:munge_gmt_dates, 'justin bieber on a train')
-        expect(munged).to eq 'justin bieber on a train'
-      end
-
-      it "should return GMT-less ical strings unmodified" do
-        icard = %{
-BEGIN:VCALENDAR
-BEGIN:VEVENT
-DTSTART:20200507T080000
-DTEND:20200507T090000
-END:VEVENT
-END:VCALENDAR
-        }
-
-        expect(Source::Parser::Ical.new.send(:munge_gmt_dates, icard)).to eq icard
-      end
-
-      it "should replace TZID=GMT with a TZID-less UTC time" do
-        icard = %{
-BEGIN:VCALENDAR
-BEGIN:VEVENT
-DTSTART;TZID=GMT:20200507T080000
-DTEND;TZID=GMT:20200507T090000
-END:VEVENT
-END:VCALENDAR
-        }
-
-        munged = %{
-BEGIN:VCALENDAR
-BEGIN:VEVENT
-DTSTART:20200507T080000Z
-DTEND:20200507T090000Z
-END:VEVENT
-END:VCALENDAR
-        }
-
-        expect(Source::Parser::Ical.new.send(:munge_gmt_dates, icard)).to eq munged
-      end
-    end
-
     describe "when skipping old events" do
       before(:each) do
         url = "http://foo.bar/"

--- a/spec/models/calagator/source/parser_ical_spec.rb
+++ b/spec/models/calagator/source/parser_ical_spec.rb
@@ -63,18 +63,23 @@ module Calagator
       end
 
       it "should match each event with its venue" do
-        event_titles_and_street_addresses = [
+        expect(@events.map { |event| [event.title, event.venue.street_address] }).to eq [
           ["iMovie and iDVD Workshop", "7293 SW Bridgeport Road"],
+          ["iMovie and iDVD Workshop", "700 Southwest Fifth Avenue Suite #1035"],
           ["Portland Macintosh Users Group (PMUG)", "Jean Vollum Natural Capital Center"],
-          ["Morning Meetings: IT", "622 SE Grand Avenue"]
+          ["Morning Meetings: IT", "622 SE Grand Avenue"],
+          ["Portland Python Users' Group", "622 SE Grand Avenue"],
+          ["Computer Basics Class", "12375 SW Fifth Street"],
+          ["Code 'n' Splode", "622 SE Grand Avenue"],
+          ["Google Analytics Seminars for Success in Portland,OR", "310 SW Lincoln Street"],
+          ["PDXPHP Monthly Meeting", "1731 SE Tenth Avenue"],
+          ["Portland Ruby Brigade", "622 SE Grand Avenue"],
+          ["Portland Cisco Router Training: 2-Day Hands-On Seminar", "15525 NW Gateway Court"],
+          ["Post Card & Souvenir Distributors Association Convention & Tra de Show", "1000 NE Multnomah"],
+          ["Portland Cisco ASA Training:  2-Day Hands-On Seminar", "15525 NW Gateway Court"],
+          ["Mythbusters", "Southwest Broadway at Main Street"],
+          ["Wood Technology Clinic & Show", "777 NE Martin Luther King Jr Boulevard"],
         ]
-
-        # Make sure each of the above events has the expected street address
-        event_titles_and_street_addresses.each do |event_title, street_address|
-          expect(@events.find { |event|
-            event.title == event_title && event.venue.street_address == street_address
-          }).not_to be_nil
-        end
       end
     end
 

--- a/spec/models/calagator/source/parser_spec.rb
+++ b/spec/models/calagator/source/parser_spec.rb
@@ -2,6 +2,12 @@ require 'spec_helper'
 
 module Calagator
   describe Source::Parser, type: :model do
+    around do |example|
+      Timecop.freeze("2000-01-01") do
+        example.run
+      end
+    end
+
     describe "when reading content" do
       it "should read from a normal URL" do
         stub_request(:get, "http://a.real/~url").to_return(body: "42")
@@ -66,7 +72,7 @@ module Calagator
       </div>})
           stub_request(:get, url).to_return(body: @cal_content)
           @events = @cal_source.to_events
-          @created_events = @cal_source.create_events!(:skip_old => false)
+          @created_events = @cal_source.create_events!
         end
 
         it "should only parse one event" do
@@ -107,7 +113,7 @@ module Calagator
           stub_request(:get, url).to_return(body: cal_content)
 
           cal_source = Source.new(title: "Calendar event feed", url: url)
-          imported_event = cal_source.create_events!(:skip_old => false).first
+          imported_event = cal_source.create_events!.first
           expect(imported_event).not_to be_marked_as_duplicate
         end
       end
@@ -137,7 +143,7 @@ module Calagator
 
           cal_source = Source.new(title: "Calendar event feed", url: url)
           @parsed_events  = cal_source.to_events
-          @created_events = cal_source.create_events!(:skip_old => false)
+          @created_events = cal_source.create_events!
         end
 
         it "should parse two events" do
@@ -177,7 +183,7 @@ module Calagator
 
         source = Source.new(title: "Event with squashed venue", url: url)
 
-        event = source.to_events(:skip_old => false).first
+        event = source.to_events.first
         expect(event.venue.title).to eq "Master"
       end
 
@@ -190,7 +196,7 @@ module Calagator
 
         source = Source.new(title: "Event with duplicate machine-tagged venue", url: plancast_url)
 
-        event = source.to_events(:skip_old => false).first
+        event = source.to_events.first
 
         expect(event.venue).to eq venue
       end

--- a/spec/models/calagator/source/parser_spec.rb
+++ b/spec/models/calagator/source/parser_spec.rb
@@ -1,59 +1,59 @@
 require 'spec_helper'
 
 module Calagator
+  describe Source::Parser, type: :model do
+    describe "when reading content" do
+      it "should read from a normal URL" do
+        stub_request(:get, "http://a.real/~url").to_return(body: "42")
+        expect(Source::Parser.read_url("http://a.real/~url")).to eq "42"
+      end
 
-describe Source::Parser, "when reading content", :type => :model do
-  it "should read from a normal URL" do
-    stub_request(:get, "http://a.real/~url").to_return(body: "42")
-    expect(Source::Parser.read_url("http://a.real/~url")).to eq "42"
-  end
+      it "should raise an error when unauthorized" do
+        stub_request(:get, "http://a.private/~url").to_return(status: [401, "Forbidden"])
+        expect {
+          Source::Parser.read_url("http://a.private/~url")
+        }.to raise_error Source::Parser::HttpAuthenticationRequiredError
+      end
+    end
 
-  it "should raise an error when unauthorized" do
-    stub_request(:get, "http://a.private/~url").to_return(status: [401, "Forbidden"])
-    expect {
-      Source::Parser.read_url("http://a.private/~url")
-    }.to raise_error Source::Parser::HttpAuthenticationRequiredError
-  end
-end
+    describe "when subclassing" do
+      it "should demand that #to_events is implemented" do
+        expect{ Source::Parser.new.to_events }.to raise_error NotImplementedError
+      end
+    end
 
-describe Source::Parser, "when subclassing", :type => :model do
-  it "should demand that #to_events is implemented" do
-    expect{ Source::Parser.new.to_events }.to raise_error NotImplementedError
-  end
-end
+    describe "when parsing events" do
+      it "should have site-specific parsers first, then generics" do
+        expect(Source::Parser.parsers.to_a).to eq [
+          Source::Parser::Facebook,
+          Source::Parser::Meetup,
+          Source::Parser::Plancast,
+          Source::Parser::Hcal,
+          Source::Parser::Ical,
+        ]
+      end
 
-describe Source::Parser, "when parsing events", :type => :model do
-  it "should have site-specific parsers first, then generics" do
-    expect(Source::Parser.parsers.to_a).to eq [
-      Source::Parser::Facebook,
-      Source::Parser::Meetup,
-      Source::Parser::Plancast,
-      Source::Parser::Hcal,
-      Source::Parser::Ical,
-    ]
-  end
+      it "should use first successful parser's results" do
+        events = [double]
 
-  it "should use first successful parser's results" do
-    events = [double]
+        body = {
+          name: "event",
+          start_time: "2010-01-01 12:00:00 UTC",
+          end_time: "2010-01-01 13:00:00 UTC"
+        }.to_json
+        stub_request(:get, "http://graph.facebook.com/omg").to_return(body: body, headers: { content_type: "application/json" })
 
-    body = {
-      name: "event",
-      start_time: "2010-01-01 12:00:00 UTC",
-      end_time: "2010-01-01 13:00:00 UTC"
-    }.to_json
-    stub_request(:get, "http://graph.facebook.com/omg").to_return(body: body, headers: { content_type: "application/json" })
+        expect(Source::Parser.to_events(url: "http://www.facebook.com/events/omg")).to have(1).event
+      end
+    end
 
-    expect(Source::Parser.to_events(url: "http://www.facebook.com/events/omg")).to have(1).event
-  end
-end
-
-describe Source::Parser, "checking duplicates when importing", :type => :model do
-  describe "with two identical events" do
-    before :each do
-      @venue_size_before_import = Venue.count
-      url = "http://mysample.hcal/"
-      @cal_source = Source.new(title: "Calendar event feed", url: url)
-      @cal_content = (%{
+    describe "checking duplicates when importing" do
+      describe "with two identical events" do
+        before :each do
+          @venue_size_before_import = Venue.count
+          url = "http://mysample.hcal/"
+          @cal_source = Source.new(title: "Calendar event feed", url: url)
+          @cal_content = (%{
       <div class="vevent">
         <abbr class="dtstart" title="20080714"></abbr>
         <abbr class="summary" title="Bastille Day"></abbr>
@@ -64,63 +64,63 @@ describe Source::Parser, "checking duplicates when importing", :type => :model d
         <abbr class="summary" title="Bastille Day"></abbr>
         <abbr class="location" title="Arc de Triomphe"></abbr>
       </div>})
-      stub_request(:get, url).to_return(body: @cal_content)
-      @events = @cal_source.to_events
-      @created_events = @cal_source.create_events!(:skip_old => false)
-    end
+          stub_request(:get, url).to_return(body: @cal_content)
+          @events = @cal_source.to_events
+          @created_events = @cal_source.create_events!(:skip_old => false)
+        end
 
-    it "should only parse one event" do
-      expect(@events.size).to eq 1
-    end
+        it "should only parse one event" do
+          expect(@events.size).to eq 1
+        end
 
-    it "should create only one event" do
-      expect(@created_events.size).to eq 1
-    end
+        it "should create only one event" do
+          expect(@created_events.size).to eq 1
+        end
 
-    it "should create only one venue" do
-      expect(Venue.count).to eq @venue_size_before_import + 1
-    end
-  end
+        it "should create only one venue" do
+          expect(Venue.count).to eq @venue_size_before_import + 1
+        end
+      end
 
-  describe "with an event" do
-    it "should retrieve an existing event if it's an exact duplicate" do
-      url = "http://mysample.hcal/"
-      hcal_source = Source.new(title: "Calendar event feed", url: url)
-      stub_request(:get, url).to_return(body: read_sample('hcal_event_duplicates_fixture.xml'))
+      describe "with an event" do
+        it "should retrieve an existing event if it's an exact duplicate" do
+          url = "http://mysample.hcal/"
+          hcal_source = Source.new(title: "Calendar event feed", url: url)
+          stub_request(:get, url).to_return(body: read_sample('hcal_event_duplicates_fixture.xml'))
 
-      event = hcal_source.to_events.first
-      event.save!
+          event = hcal_source.to_events.first
+          event.save!
 
-      event2 = hcal_source.to_events.first
-      expect(event2).not_to be_a_new_record
-    end
+          event2 = hcal_source.to_events.first
+          expect(event2).not_to be_a_new_record
+        end
 
-    it "an event with a orphaned exact duplicate should should remove duplicate marking" do
-      orphan = Event.create!(:title => "orphan", :start_time => Time.parse("July 14 2008"), :duplicate_of_id => 7142008 )
-      cal_content = %(
+        it "an event with a orphaned exact duplicate should should remove duplicate marking" do
+          orphan = Event.create!(:title => "orphan", :start_time => Time.parse("July 14 2008"), :duplicate_of_id => 7142008 )
+          cal_content = %(
         <div class="vevent">
         <abbr class="summary" title="orphan"></abbr>
         <abbr class="dtstart" title="20080714"></abbr>
         </div>
-      )
-      url = "http://mysample.hcal/"
-      stub_request(:get, url).to_return(body: cal_content)
+          )
+          url = "http://mysample.hcal/"
+          stub_request(:get, url).to_return(body: cal_content)
 
-      cal_source = Source.new(title: "Calendar event feed", url: url)
-      imported_event = cal_source.create_events!(:skip_old => false).first
-      expect(imported_event).not_to be_marked_as_duplicate
-    end
-  end
+          cal_source = Source.new(title: "Calendar event feed", url: url)
+          imported_event = cal_source.create_events!(:skip_old => false).first
+          expect(imported_event).not_to be_marked_as_duplicate
+        end
+      end
 
-  describe "should create two events when importing two non-identical events" do
-    # This behavior is tested under
-    #  describe Source::Parser::Hcal, "with hCalendar events" do
-    #  'it "should parse a page with multiple events" '
-  end
+      describe "should create two events when importing two non-identical events" do
+        # This behavior is tested under
+        #  describe Source::Parser::Hcal, "with hCalendar events" do
+        #  'it "should parse a page with multiple events" '
+      end
 
-  describe "two identical events with different venues" do
-    before(:each) do
-      cal_content = %(
+      describe "two identical events with different venues" do
+        before(:each) do
+          cal_content = %(
         <div class="vevent">
           <abbr class="dtstart" title="20080714"></abbr>
           <abbr class="summary" title="Bastille Day"></abbr>
@@ -131,108 +131,108 @@ describe Source::Parser, "checking duplicates when importing", :type => :model d
           <abbr class="summary" title="Bastille Day"></abbr>
           <abbr class="location" title="Bastille"></abbr>
         </div>
-      )
-      url = "http://mysample.hcal/"
-      stub_request(:get, url).to_return(body: cal_content)
+          )
+          url = "http://mysample.hcal/"
+          stub_request(:get, url).to_return(body: cal_content)
 
-      cal_source = Source.new(title: "Calendar event feed", url: url)
-      @parsed_events  = cal_source.to_events
-      @created_events = cal_source.create_events!(:skip_old => false)
-    end
+          cal_source = Source.new(title: "Calendar event feed", url: url)
+          @parsed_events  = cal_source.to_events
+          @created_events = cal_source.create_events!(:skip_old => false)
+        end
 
-    it "should parse two events" do
-      expect(@parsed_events.size).to eq 2
-    end
+        it "should parse two events" do
+          expect(@parsed_events.size).to eq 2
+        end
 
-    it "should create two events" do
-      expect(@created_events.size).to eq 2
-    end
+        it "should create two events" do
+          expect(@created_events.size).to eq 2
+        end
 
-     it "should have different venues for the parsed events" do
-      expect(@parsed_events[0].venue).not_to eq @parsed_events[1].venue
-    end
+        it "should have different venues for the parsed events" do
+          expect(@parsed_events[0].venue).not_to eq @parsed_events[1].venue
+        end
 
-     it "should have different venues for the created events" do
-      expect(@created_events[0].venue).not_to eq @created_events[1].venue
-    end
-  end
+        it "should have different venues for the created events" do
+          expect(@created_events[0].venue).not_to eq @created_events[1].venue
+        end
+      end
 
-  it "should use an existing venue when importing an event whose venue matches a squashed duplicate"  do
-    dummy_source = Source.create!(:title => "Dummy", :url => "http://IcalEventWithSquashedVenue.com/")
-    master_venue = Venue.create!(:title => "Master")
-    squashed_venue = Venue.create!(
-      :title => "Squashed Duplicate Venue",
-      :duplicate_of_id => master_venue.id)
+      it "should use an existing venue when importing an event whose venue matches a squashed duplicate"  do
+        dummy_source = Source.create!(:title => "Dummy", :url => "http://IcalEventWithSquashedVenue.com/")
+        master_venue = Venue.create!(:title => "Master")
+        squashed_venue = Venue.create!(
+          :title => "Squashed Duplicate Venue",
+          :duplicate_of_id => master_venue.id)
 
-    cal_content = %(
+        cal_content = %(
       <div class="vevent">
         <abbr class="dtstart" title="20090117"></abbr>
         <abbr class="summary" title="Event with cloned venue"></abbr>
         <abbr class="location" title="Squashed Duplicate Venue"></abbr>
       </div>
-    )
+        )
 
-    url = "http://mysample.hcal/"
-    stub_request(:get, url).to_return(body: cal_content)
+        url = "http://mysample.hcal/"
+        stub_request(:get, url).to_return(body: cal_content)
 
-    source = Source.new(title: "Event with squashed venue", url: url)
+        source = Source.new(title: "Event with squashed venue", url: url)
 
-    event = source.to_events(:skip_old => false).first
-    expect(event.venue.title).to eq "Master"
-  end
+        event = source.to_events(:skip_old => false).first
+        expect(event.venue.title).to eq "Master"
+      end
 
-  it "should use an existing venue when importing an event with a matching machine tag that describes a venue" do
-    venue = Venue.create!(:title => "Custom Urban Airship", :tag_list => "plancast:place=1520153")
+      it "should use an existing venue when importing an event with a matching machine tag that describes a venue" do
+        venue = Venue.create!(:title => "Custom Urban Airship", :tag_list => "plancast:place=1520153")
 
-    plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
-    api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
-    stub_request(:get, api_url).to_return(body: read_sample('plancast.json'), headers: { content_type: "application/json" })
+        plancast_url = 'http://plancast.com/p/3cos/indiewebcamp'
+        api_url = 'http://api.plancast.com/02/plans/show.json?extensions=place&plan_id=3cos'
+        stub_request(:get, api_url).to_return(body: read_sample('plancast.json'), headers: { content_type: "application/json" })
 
-    source = Source.new(title: "Event with duplicate machine-tagged venue", url: plancast_url)
+        source = Source.new(title: "Event with duplicate machine-tagged venue", url: plancast_url)
 
-    event = source.to_events(:skip_old => false).first
+        event = source.to_events(:skip_old => false).first
 
-    expect(event.venue).to eq venue
-  end
+        expect(event.venue).to eq venue
+      end
 
-  describe "choosing parsers by matching URLs" do
-    { "Calagator::Source::Parser::Plancast" => "http://plancast.com/p/3cos/indiewebcamp",
-      "Calagator::Source::Parser::Meetup"   => "http://www.meetup.com/pdxweb/events/23287271/" }.each do |parser_name, url|
+      describe "choosing parsers by matching URLs" do
+        { "Calagator::Source::Parser::Plancast" => "http://plancast.com/p/3cos/indiewebcamp",
+          "Calagator::Source::Parser::Meetup"   => "http://www.meetup.com/pdxweb/events/23287271/" }.each do |parser_name, url|
 
-      it "should only invoke the #{parser_name} parser when given #{url}" do
-        parser = parser_name.constantize
-        expect_any_instance_of(parser).to receive(:to_events).and_return([Event.new])
-        Source::Parser.parsers.reject{|p| p == parser }.each do |other_parser|
-          expect_any_instance_of(other_parser).not_to receive :to_events
+          it "should only invoke the #{parser_name} parser when given #{url}" do
+            parser = parser_name.constantize
+            expect_any_instance_of(parser).to receive(:to_events).and_return([Event.new])
+            Source::Parser.parsers.reject{|p| p == parser }.each do |other_parser|
+              expect_any_instance_of(other_parser).not_to receive :to_events
+            end
+
+            stub_request(:get, url)
+            Source.new(:title => parser_name, :url => url).to_events
+          end
         end
+      end
+    end
 
-        stub_request(:get, url)
-        Source.new(:title => parser_name, :url => url).to_events
+    describe "labels" do
+      it "should have labels" do
+        expect(Source::Parser.labels).not_to be_blank
+      end
+
+      it "should have labels for each parser" do
+        expect(Source::Parser.labels.size).to eq Source::Parser.parsers.size
+      end
+
+      it "should use the label of the parser, as a string" do
+        label = Source::Parser.parsers.first.label.to_s
+        expect(Source::Parser.labels).to include label
+      end
+
+      it "should have sorted labels" do
+        labels = Source::Parser.labels
+        sorted = labels.sort_by(&:downcase)
+
+        expect(labels).to eq sorted
       end
     end
   end
-end
-
-describe Source::Parser, "labels", :type => :model do
-  it "should have labels" do
-    expect(Source::Parser.labels).not_to be_blank
-  end
-
-  it "should have labels for each parser" do
-    expect(Source::Parser.labels.size).to eq Source::Parser.parsers.size
-  end
-
-  it "should use the label of the parser, as a string" do
-    label = Source::Parser.parsers.first.label.to_s
-    expect(Source::Parser.labels).to include label
-  end
-
-  it "should have sorted labels" do
-    labels = Source::Parser.labels
-    sorted = labels.sort_by(&:downcase)
-
-    expect(labels).to eq sorted
-  end
-end
-
 end

--- a/spec/models/calagator/source_spec.rb
+++ b/spec/models/calagator/source_spec.rb
@@ -10,6 +10,7 @@ describe Source, "in general", :type => :model do
       :url => "http://my.url/",
       :start_time => Time.now + 1.day,
       :end_time => nil,
+      :old? => false,
       :venue => nil,
       :duplicate_of_id => nil)
   end


### PR DESCRIPTION
Major refactor of the complex `Source::Parser::Ical` class.

`RiCal` wasn't quite giving us what we need in terms of converting raw iCal strings into values to plug into `Event`s and `Venue`s. Most of `Source::Parser::Ical` was just trying to massage the data from `RiCal` into reasonable values, which seems a bit too low level. I've extracted a new micro library named `VCalendar` that wraps `RiCal`, and gives us reasonable values in the form of `VVenue`s and `VEvent`s. `Source::Parser::Ical` can now operate at a higher level of abstraction, and just deal with the importing process without knowing anything about the nitty gritty of the impedance mismatch with `RiCal`.

As an aside, `RiCal` appears to have been abandoned for over four years, so this paves the way for easily swapping it out with a different maintained library.

Some ancillary refactoring of the entire `Source::Parser` aggregate:
* Noticed that the `:skip_old?` option only existed to facilitate testing. Replaced it with `Time` stubbing.
* Removed the opaque `opts` hash that was flowing between several parsing components and encouraging coupling between them. Replaced with normal parameters so that we're only passing what we actually need.