### PR TITLE
Replace custom JSONP handling with Rack::JSONP

### DIFF
--- a/app/controllers/calagator/events_controller.rb
+++ b/app/controllers/calagator/events_controller.rb
@@ -112,7 +112,7 @@ class EventsController < Calagator::ApplicationController
     respond_to do |format|
       format.html # show.html.erb
       format.xml  { render :xml  => event.to_xml(root: "events", :include => :venue) }
-      format.json { render :json => event.to_json(:include => :venue), :callback => params[:callback] }
+      format.json { render :json => event.to_json(:include => :venue) }
       format.ics  { render :ics  => [event] }
     end
   end
@@ -125,7 +125,7 @@ class EventsController < Calagator::ApplicationController
       format.ics  { render :ics => events || Event.future.non_duplicates }
       format.atom { render :template => 'calagator/events/index' }
       format.xml  { render :xml  => events.to_xml(root: "events", :include => :venue) }
-      format.json { render :json => events.to_json(:include => :venue), :callback => params[:callback] }
+      format.json { render :json => events.to_json(:include => :venue) }
     end
   end
 

--- a/app/controllers/calagator/venues_controller.rb
+++ b/app/controllers/calagator/venues_controller.rb
@@ -27,8 +27,8 @@ class VenuesController < Calagator::ApplicationController
       format.html # index.html.erb
       format.kml  # index.kml.erb
       format.xml  { render xml:  venues }
-      format.json { render json: venues, callback: params[:callback] }
-      format.js   { render json: venues, callback: params[:callback] }
+      format.json { render json: venues }
+      format.js   { render json: venues }
     end
   end
   private :render_venues
@@ -42,7 +42,7 @@ class VenuesController < Calagator::ApplicationController
       .where(["LOWER(title) LIKE ?", "%#{params[:term]}%".downcase])
       .order('LOWER(title)')
 
-    render json: @venues, callback: params[:callback]
+    render json: @venues
   end
 
 
@@ -78,7 +78,7 @@ class VenuesController < Calagator::ApplicationController
       respond_to do |format|
         format.html
         format.xml  { render xml: venue }
-        format.json { render json: venue, callback: params[:callback] }
+        format.json { render json: venue }
         format.ics  { render ics: venue_events }
       end
     end

--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sunspot_rails", "~> 2.1"
   s.add_dependency "sunspot_solr",  "~> 2.1"
   s.add_dependency "lucene_query", "0.1"
+  s.add_dependency "rack-contrib", "~> 1.0"
 
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency "rspec-activemodel-mocks", "~> 1.0.2"

--- a/lib/calagator.rb
+++ b/lib/calagator.rb
@@ -24,6 +24,7 @@ require "utf8-cleaner"
 require "sunspot_rails"
 require "sunspot_solr"
 require "lucene_query"
+require "rack/contrib/jsonp"
 
 module Calagator
   mattr_accessor :title,

--- a/lib/calagator/engine.rb
+++ b/lib/calagator/engine.rb
@@ -2,6 +2,8 @@ module Calagator
   class Engine < ::Rails::Engine
     isolate_namespace Calagator
 
+    middleware.use "Rack::JSONP"
+
     config.assets.precompile += %w( 
       markers-soft.png
       markers-shadow.png

--- a/spec/controllers/calagator/events_controller_spec.rb
+++ b/spec/controllers/calagator/events_controller_spec.rb
@@ -59,12 +59,6 @@ describe EventsController, :type => :controller do
     end
 
     describe "as JSON" do
-      it "should accept a JSONP callback" do
-        get :index, :format => "json", :callback => "some_function"
-
-        expect(response.body.split("\n").join).to match /some_function\(.*\)\Z/
-      end
-
       describe "without events" do
         before do
           get :index, :format => "json"
@@ -702,12 +696,6 @@ describe EventsController, :type => :controller do
 
           struct = ActiveSupport::JSON.decode(response.body)
           expect(struct).to be_a_kind_of Array
-        end
-
-        it "should accept a JSONP callback" do
-          get :search, :query => "myquery", :format => "json", :callback => "some_function"
-
-          expect(response.body).to match /some_function\(.*\)$/
         end
 
         it "should include venue details" do

--- a/spec/controllers/calagator/venues_controller_spec.rb
+++ b/spec/controllers/calagator/venues_controller_spec.rb
@@ -127,12 +127,6 @@ describe VenuesController, :type => :controller do
         struct = ActiveSupport::JSON.decode(response.body)
         expect(struct).to be_a_kind_of Array
       end
-
-      it "should accept a JSONP callback" do
-        xhr :get, :index, :format => "json", :callback => "some_function"
-
-        expect(response.body.split("\n").join).to match /some_function\(.*\)$/
-      end
     end
 
   end
@@ -158,12 +152,6 @@ describe VenuesController, :type => :controller do
           %w[id title description address].each do |field|
             expect(struct[field]).to eq @venue.send(field)
           end
-        end
-
-        it "should accept a JSONP callback" do
-          xhr :get, :show, :id => @venue.to_param, :format => "json", :callback => "some_function"
-
-          expect(response.body.split("\n").join).to match /some_function\(.*\)$/
         end
       end
     end

--- a/spec/features/jsonp_output_spec.rb
+++ b/spec/features/jsonp_output_spec.rb
@@ -4,6 +4,6 @@ require 'rails_helper'
 feature "JSONP API results" do
   scenario "User requests events.json with a JSONP callback specified" do
     visit "/events.json?callback=myFunction"
-    expect(page).to have_content /^myFunction\(/
+    expect(page).to have_content /^(?:\/\*\*\/)?myFunction\(/
   end
 end

--- a/spec/features/jsonp_output_spec.rb
+++ b/spec/features/jsonp_output_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+# Basic middleware integration test to ensure Rack::JSONP continues to do its job
+feature "JSONP API results" do
+  scenario "User requests events.json with a JSONP callback specified" do
+    visit "/events.json?callback=myFunction"
+    expect(page).to have_content /^myFunction\(/
+  end
+end


### PR DESCRIPTION
This removes all of Calagator's custom JSONP response generation code
in favor of the more complete and nuanced implementation provided by
rack-contrib's Rack::JSONP middleware

Hopefully fixes #441, though more investigation may be needed.