### PR TITLE
Memoize Calagator::VCalendar#vvenues to speed up iCal imports

### DIFF
--- a/lib/calagator/vcalendar.rb
+++ b/lib/calagator/vcalendar.rb
@@ -24,7 +24,7 @@ module Calagator
     VENUE_CONTENT_RE = /^BEGIN:VVENUE$.*?^END:VVENUE$/m
 
     def vvenues
-      ri_cal_calendar.to_s.scan(VENUE_CONTENT_RE).map do |raw_ical_venue|
+      @vvenues ||= ri_cal_calendar.to_s.scan(VENUE_CONTENT_RE).map do |raw_ical_venue|
         VVenue.new(raw_ical_venue)
       end
     end


### PR DESCRIPTION
We call this method once for every event we import, so calculating it every time is costly (~7min for a 1300-event source on my laptop). Time to import that same source is down to 1.6 seconds after this change.

Fixes #481