### PR TITLE
Fix pain points with Meetup event import

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -30,6 +30,7 @@ These people have contributed to Calagator's design and implementation:
   * Fred Willmore
   * Gabrielle Roth
   * Garrison Jensen
+  * Guru Khalsa
   * Igal Koshevoy
   * James Kurczodyna
   * Jeff Schwaber

--- a/app/controllers/calagator/sources_controller.rb
+++ b/app/controllers/calagator/sources_controller.rb
@@ -7,7 +7,11 @@ class SourcesController < Calagator::ApplicationController
     @importer = Source::Importer.new(params.permit![:source])
     respond_to do |format|
       if @importer.import
-        format.html { redirect_to events_path, flash: { success: render_to_string(layout: false) } }
+        if @importer.events.count == 1
+          format.html { redirect_to @importer.events.first, flash: { success: render_to_string(layout: false) } }
+        else
+          format.html { redirect_to events_path, flash: { success: render_to_string(layout: false) } }
+        end
         format.xml  { render xml: @importer.source, events: @importer.events }
       else
         format.html { redirect_to new_source_path(url: @importer.source.url), flash: { failure: @importer.failure_message } }

--- a/app/controllers/calagator/sources_controller.rb
+++ b/app/controllers/calagator/sources_controller.rb
@@ -7,7 +7,7 @@ class SourcesController < Calagator::ApplicationController
     @importer = Source::Importer.new(params.permit![:source])
     respond_to do |format|
       if @importer.import
-        redirect_target = @importer.events.count == 1 ? @importer.events.first : events_path
+        redirect_target = @importer.events.one? ? @importer.events.first : events_path
         format.html { redirect_to redirect_target, flash: { success: render_to_string(layout: false) } }
         format.xml  { render xml: @importer.source, events: @importer.events }
       else

--- a/app/controllers/calagator/sources_controller.rb
+++ b/app/controllers/calagator/sources_controller.rb
@@ -7,11 +7,8 @@ class SourcesController < Calagator::ApplicationController
     @importer = Source::Importer.new(params.permit![:source])
     respond_to do |format|
       if @importer.import
-        if @importer.events.count == 1
-          format.html { redirect_to @importer.events.first, flash: { success: render_to_string(layout: false) } }
-        else
-          format.html { redirect_to events_path, flash: { success: render_to_string(layout: false) } }
-        end
+        redirect_target = @importer.events.count == 1 ? @importer.events.first : events_path
+        format.html { redirect_to redirect_target, flash: { success: render_to_string(layout: false) } }
         format.xml  { render xml: @importer.source, events: @importer.events }
       else
         format.html { redirect_to new_source_path(url: @importer.source.url), flash: { failure: @importer.failure_message } }

--- a/app/models/calagator/source/parser/meetup.rb
+++ b/app/models/calagator/source/parser/meetup.rb
@@ -14,7 +14,7 @@ class Source::Parser::Meetup < Source::Parser
       description: data['description'],
       url:         data['event_url'],
       venue:       to_venue(data['venue']),
-      tag_list:    "meetup:event=#{data['event_id']}, meetup:group=#{data['group']['urlname']}#{get_group_topics(data)}",
+      tag_list:    "meetup:event=#{data['event_id']}, meetup:group=#{data['group']['urlname']}#{group_topics(data)}",
       # Meetup sends us milliseconds since the epoch in UTC
       start_time:  start_time,
       end_time: data['duration'] ? start_time + data['duration']/1000 : nil
@@ -33,11 +33,6 @@ class Source::Parser::Meetup < Source::Parser
     )
   end
 
-  def get_group_topics(data)
-    group_topics = data['group']['topics']
-    group_topics.map{ |t| t['name'].downcase }.join(', ').insert(0, ', ') unless group_topics.empty?
-  end
-
   def get_data
     to_events_api_helper(url, "problem") do |event_id|
       [
@@ -49,6 +44,11 @@ class Source::Parser::Meetup < Source::Parser
         }
       ]
     end
+  end
+
+  def group_topics(data)
+    topics = data['group']['topics']
+    topics.map{ |t| t['name'].downcase }.join(', ').insert(0, ', ') unless topics.empty?
   end
 
   def to_venue(value)

--- a/app/models/calagator/source/parser/meetup.rb
+++ b/app/models/calagator/source/parser/meetup.rb
@@ -2,7 +2,6 @@ module Calagator
 
 class Source::Parser::Meetup < Source::Parser
   self.label = :Meetup
-  #change url pattern to: %r{^http://(?:www\.)?meetup\.com/([^/]+)/events/([^/]+)/?}  then also need to change to_events_api_helper 
   self.url_pattern = %r{^http://(?:www\.)?meetup\.com/[^/]+/events/([^/]+)/?}
 
   def to_events

--- a/spec/models/calagator/source/parser_meetup_spec.rb
+++ b/spec/models/calagator/source/parser_meetup_spec.rb
@@ -10,7 +10,7 @@ describe Source::Parser::Meetup, :type => :model do
 
     before(:each) do
       meetup_url = "http://www.meetup.com/pdxpython/events/ldhnqyplbnb/"
-      api_url = "https://api.meetup.com/2/event/ldhnqyplbnb?key=foo&sign=true"
+      api_url = "https://api.meetup.com/2/event/ldhnqyplbnb?key=foo&sign=true&fields=topics"
 
       stub_request(:get, api_url).to_return(body: read_sample('meetup.json'), headers: { content_type: "application/json" })
       @events = Source::Parser::Meetup.to_events(url: meetup_url)
@@ -22,12 +22,12 @@ describe Source::Parser::Meetup, :type => :model do
     end
 
     it "should set event details" do
-      expect(@event.title).to eq "eLearning Network Meetup"
+      expect(@event.title).to eq "eLearning Network - eLearning Network Meetup"
       expect(@event.start_time).to eq Time.zone.parse("Thu Aug 11 00:00:00 UTC 2011")
     end
 
     it "should tag Meetup events with automagic machine tags" do
-      expect(@event.tag_list).to eq ["meetup:event=ldhnqyplbnb", "meetup:group=eLearningNetwork"]
+      expect(@event.tag_list).to eq ["meetup:event=ldhnqyplbnb", "meetup:group=eLearningNetwork", "ruby", "python", "javascript"]
     end
 
     it "should populate a venue when structured data is provided" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,6 @@ require "capybara/poltergeist"
 require "timecop"
 require "webmock"
 
-
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,7 @@ require "capybara/poltergeist"
 require "timecop"
 require "webmock"
 
+
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 

--- a/spec/support/samples/meetup.json
+++ b/spec/support/samples/meetup.json
@@ -26,6 +26,23 @@
         "name": "eLearning Network",
         "group_lon": -122.69000244140625,
         "join_mode": "open",
-        "urlname": "eLearningNetwork"
+        "urlname": "eLearningNetwork",
+        "topics": [
+            {
+            "urlkey": "ruby",
+            "name": "Ruby",
+            "id": 1040
+            },
+            {
+            "urlkey": "python",
+            "name": "Python",
+            "id": 1064
+            },
+            {
+            "urlkey": "javascript",
+            "name": "JavaScript",
+            "id": 7029
+            }
+        ]
     }
 }


### PR DESCRIPTION
This addresses #251.  I included the group name in the title using the format "group name - event title", but please let me know if it should be formatted differently.
An end time is now being assigned to Events if duration is given.  Meetup recommends estimating a duration of 3 hours if none is given but discussion around issue #16 seemed to indicate that leaving it blank was preferable so that's how I implemented it.
Meetup group tags are now being imported as well and added to the Event's tag list.
My impression is that the Parsers are setup to import multiple Events if they are found, which is probably why the import redirects to the main page instead of an imported Event, but I updated it so that if only one Event is imported it will redirect to that newly imported Event's page.