### PR TITLE
Match HTTPS meetup.com URLs in Source::Parser::Meetup

### DIFF
--- a/app/models/calagator/source/parser/meetup.rb
+++ b/app/models/calagator/source/parser/meetup.rb
@@ -2,7 +2,7 @@ module Calagator
 
 class Source::Parser::Meetup < Source::Parser
   self.label = :Meetup
-  self.url_pattern = %r{^http://(?:www\.)?meetup\.com/[^/]+/events/([^/]+)/?}
+  self.url_pattern = %r{^https?://(?:www\.)?meetup\.com/[^/]+/events/([^/]+)/?}
 
   def to_events
     return fallback unless Calagator.meetup_api_key.present?

--- a/spec/models/calagator/source/parser_meetup_spec.rb
+++ b/spec/models/calagator/source/parser_meetup_spec.rb
@@ -17,6 +17,14 @@ describe Source::Parser::Meetup, :type => :model do
       @event = @events.first
     end
 
+    it "matches HTTP meetup URLs" do
+      expect(subject.url_pattern).to match "http://www.meetup.com/pdxpython/events/ldhnqyplbnb/"
+    end
+
+    it "matches HTTPS meetup URLs" do
+      expect(subject.url_pattern).to match "https://www.meetup.com/pdxpython/events/ldhnqyplbnb/"
+    end
+
     it "should find one event" do
       expect(@events.size).to eq 1
     end


### PR DESCRIPTION
Fixes #506