### PR TITLE
Refer to HTTPS versions of resources whenever possible

### DIFF
--- a/app/helpers/calagator/events_helper.rb
+++ b/app/helpers/calagator/events_helper.rb
@@ -42,7 +42,7 @@ module EventsHelper
   end
 
   def google_maps_url(address)
-    "http://maps.google.com/maps?q=#{URI.encode(address)}"
+    "https://maps.google.com/maps?q=#{URI.encode(address)}"
   end
 
   #---[ Event sorting ]----------------------------------------------------
@@ -91,7 +91,7 @@ module EventsHelper
       events_url(common)
   end
 
-  GOOGLE_EVENT_SUBSCRIBE_BASE = "http://www.google.com/calendar/render?cid="
+  GOOGLE_EVENT_SUBSCRIBE_BASE = "https://www.google.com/calendar/render?cid="
 
   # Returns a Google Calendar subscription URL.
   #

--- a/app/helpers/calagator/google_event_export_helper.rb
+++ b/app/helpers/calagator/google_event_export_helper.rb
@@ -15,7 +15,7 @@ module GoogleEventExportHelper
     private
 
     def url
-      "http://www.google.com/calendar/event?action=TEMPLATE&trp=true&"
+      "https://www.google.com/calendar/event?action=TEMPLATE&trp=true&"
     end
 
     def query

--- a/app/helpers/calagator/mapping_helper.rb
+++ b/app/helpers/calagator/mapping_helper.rb
@@ -6,14 +6,14 @@ module MappingHelper
   end
 
   def leaflet_js
-    Rails.env.production? ? ["http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"] : ["leaflet"]
+    Rails.env.production? ? ["https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"] : ["leaflet"]
   end
 
   def map_provider_dependencies
     {
       "stamen" => ["http://maps.stamen.com/js/tile.stamen.js?v1.2.3"],
       "mapbox" => ["https://api.tiles.mapbox.com/mapbox.js/v1.3.1/mapbox.standalone.js"],
-      "esri"   => ["http://cdn-geoweb.s3.amazonaws.com/esri-leaflet/0.0.1-beta.5/esri-leaflet.js"],
+      "esri"   => ["https://cdn-geoweb.s3.amazonaws.com/esri-leaflet/0.0.1-beta.5/esri-leaflet.js"],
       "google" => [
         "https://maps.googleapis.com/maps/api/js?key=#{Calagator.mapping_google_maps_api_key}&sensor=false",
         "leaflet_google_layer"

--- a/app/views/layouts/calagator/application.html.erb
+++ b/app/views/layouts/calagator/application.html.erb
@@ -17,9 +17,9 @@
     <!-- Stylesheets, static -->
     <%= stylesheet_link_tag 'application', :media => :all %>
 
-    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
     <!--[if lte IE 8]>
-        <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.ie.css" />
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.ie.css" />
     <![endif]-->
 
     <!-- Stylesheets, inserted  -->

--- a/spec/helpers/calagator/events_helper_spec.rb
+++ b/spec/helpers/calagator/events_helper_spec.rb
@@ -56,15 +56,15 @@ describe EventsHelper, :type => :helper do
     end
 
     it "should generate a default link" do
-      expect(method).to eq "http://www.google.com/calendar/render?cid=http%3A%2F%2Ftest.host%2Fevents.ics"
+      expect(method).to eq "https://www.google.com/calendar/render?cid=http%3A%2F%2Ftest.host%2Fevents.ics"
     end
 
     it "should generate a search link" do
-      expect(method(:query => "my query")).to eq "http://www.google.com/calendar/render?cid=http%3A%2F%2Ftest.host%2Fevents%2Fsearch.ics%3Fquery%3Dmy%2Bquery"
+      expect(method(:query => "my query")).to eq "https://www.google.com/calendar/render?cid=http%3A%2F%2Ftest.host%2Fevents%2Fsearch.ics%3Fquery%3Dmy%2Bquery"
     end
 
     it "should generate a tag link" do
-      expect(method(:tag => "mytag")).to eq "http://www.google.com/calendar/render?cid=http%3A%2F%2Ftest.host%2Fevents%2Fsearch.ics%3Ftag%3Dmytag"
+      expect(method(:tag => "mytag")).to eq "https://www.google.com/calendar/render?cid=http%3A%2F%2Ftest.host%2Fevents%2Fsearch.ics%3Ftag%3Dmytag"
     end
   end
 


### PR DESCRIPTION
HTTPS versions of resources work both when a Calagator instance is served via HTTP & via HTTPS, whereas HTTP versions cause browser warnings (when they work at all) when the Calagator instance is served via HTTPS.

stamen has an issue with its certificate chain that means it does not work via HTTPS right now, so it was not updated.