### PR TITLE
Update Ruby version in Vagrant provisioning script

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -3,7 +3,7 @@
 APPDIR="/vagrant"
 VAGRANT_USER="vagrant"
 PGSQL_VERSION=9.3
-RUBY_VERSION=2.1
+RUBY_VERSION=2.2
 
 # Fix locale so that Postgres creates databases in UTF-8
 if [ "${LANG}" != "en_US.UTF-8" ] ; then


### PR DESCRIPTION
The development environment installs Ruby version 2.1 but the application requires [>= 2.2.0 and < 2.4.0](https://github.com/calagator/calagator/blob/master/calagator.gemspec#L17). This causes an error to occur when running `vagrant up`:

```
==> default: Fetching version metadata from https://rubygems.org/
==> default: .
==> default: .
==> default: Fetching dependency metadata from https://rubygems.org/
==> default: .
==> default: Resolving dependencies...
==> default: Bundler could not find compatible versions for gem "ruby":
==> default:   In Gemfile:
==> default:     ruby
==> default: 
==> default:     calagator was resolved to 1.0.0.rc3, which depends on
==> default:       ruby (< 2.4.0, >= 2.2.0)
==> default: 
==> default: Could not find gem 'ruby (< 2.4.0, >= 2.2.0)', which is required by gem
==> default: 'calagator', in any of the sources.
```

Updating the version to 2.2 fixes this issue and `vagrant up` completes successfully.