### PR TITLE
Upgrade rails to 4.2.8 to work with ruby 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source "https://rubygems.org"
 gemspec
 
 # develop against latest rails
-gem "rails", "4.2.1"
+gem "rails", "4.2.10"
 
 # turbolinks is used by the dummy application by default
 gem "turbolinks"

--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.description = "Calagator is an open source community calendaring platform"
   s.license     = "MIT"
 
-  s.required_ruby_version = ['>= 2.2.0', '< 2.4.0']
+  s.required_ruby_version = ['>= 2.2.0']
 
   s.files = Dir["{app,config,lib,vendor}/**/*"] + Dir["db/**/*.rb"] + ["MIT-LICENSE.txt", "Rakefile", "README.md", "rails_template.rb"]
   s.test_files = Dir["spec/**/*"]
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rack-contrib", "~> 1.0"
   s.add_dependency "rails-observers"
   s.add_dependency "rails_autolink", "~> 1.1"
-  s.add_dependency "rest-client", "~> 1.8"
+  s.add_dependency "rest-client", "~> 2.0"
   s.add_dependency "ri_cal", "~> 0.8.8"
   s.add_dependency "sass", "~> 3.2"
   s.add_dependency "sass-rails"
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "appraisal", "~> 2.0"
   s.add_development_dependency "capybara", "~> 2.4"
-  s.add_development_dependency "coveralls", "~> 0.8.1"
+  s.add_development_dependency "coveralls", "~> 0.8.22"
   s.add_development_dependency "database_cleaner", "~> 1.4"
   s.add_development_dependency "factory_girl_rails", "~> 4.5"
   s.add_development_dependency "faker", "~> 1.4"
@@ -63,9 +63,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec-collection_matchers", "~> 1.1"
   s.add_development_dependency "rspec-its", "~> 1.1"
   s.add_development_dependency "rspec-rails", "~> 3.2"
-  s.add_development_dependency "simplecov", "~> 0.10.0"
+  s.add_development_dependency "simplecov", "~> 0.16.1"
   s.add_development_dependency "sqlite3", "~> 1.3"
   s.add_development_dependency "sunspot_solr",  "~> 2.1"
   s.add_development_dependency "timecop", "~> 0.7.1"
-  s.add_development_dependency "webmock", "~> 1.20"
+  s.add_development_dependency "webmock", "~> 2"
 end

--- a/rails_template.rb
+++ b/rails_template.rb
@@ -34,7 +34,7 @@ gem_group :development, :test do
   if spec
     spec_dependencies = spec.development_dependencies.select{|dep| required_dev_gems.include?(dep.name) }
     spec_dependencies.each do |dep|
-      gem dep.name, dep.requirement.to_s
+      gem dep.name.dup, dep.requirement.to_s
     end
   else
     required_dev_gems.each{|gem_name| gem gem_name }


### PR DESCRIPTION
This raises the minimal set of gem versions to make calagator work with ruby 2.5 (and possibly 2.6). Also, coveralls and rest-client had issues with 2.5.