### PR TITLE
Upgrade from factory girl to factory bot

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -10,6 +10,7 @@ These people have contributed to Calagator's design and implementation:
   * Ann-Marie Horcher
   * Anselm Hook
   * Audrey Eschright
+  * Alyssa R
   * Ben Hengst
   * Ben Kerney
   * Bill Burcham

--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "capybara", "~> 2.4"
   s.add_development_dependency "coveralls", "~> 0.8.1"
   s.add_development_dependency "database_cleaner", "~> 1.4"
-  s.add_development_dependency "factory_girl_rails", "~> 4.5"
+  s.add_development_dependency "factory_bot_rails", "~> 4.11.1"
   s.add_development_dependency "faker", "~> 1.4"
   s.add_development_dependency "gem-release", "~> 0.7"
   s.add_development_dependency "rspec-activemodel-mocks", "~> 1.0.2"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,14 +2,14 @@
 
 begin
   require 'faker'
-  require 'factory_girl'
+  require 'factory_bot_rails'
 rescue LoadError
-  puts "Calagator's seeds require faker and factory_girl."
+  puts "Calagator's seeds require faker and factory_bot_rails."
   puts "Add them to your gemfile and try again."
   exit 1
 end
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :seed_venue, class: Calagator::Venue do
     title           { Faker::Company.name }
     description     { Faker::Lorem.paragraph }
@@ -66,7 +66,7 @@ FactoryGirl.define do
 end
 
 puts "Seeding database with sample data..."
-FactoryGirl.create_list(:seed_venue, 25, :with_events)
-FactoryGirl.create_list(:seed_venue, 25)
-FactoryGirl.create_list(:seed_event, 25, :with_venue)
-FactoryGirl.create_list(:seed_event, 25)
+FactoryBot.create_list(:seed_venue, 25, :with_events)
+FactoryBot.create_list(:seed_venue, 25)
+FactoryBot.create_list(:seed_event, 25, :with_venue)
+FactoryBot.create_list(:seed_event, 25)

--- a/rails_template.rb
+++ b/rails_template.rb
@@ -24,10 +24,10 @@ if options[:database] == "postgresql" && ARGV.any? { |arg| arg =~ /--postgres-us
   end
 end
 
-# FactoryGirl and Faker are required for Calagator's db:seed task
+# FactoryBot and Faker are required for Calagator's db:seed task
 spec = Gem::Specification::load(File.expand_path("../calagator.gemspec", __FILE__))
 spec ||= Gem::Specification::find_by_name('calagator')
-required_dev_gems = ["factory_girl_rails", "faker"]
+required_dev_gems = ["factory_bot_rails", "faker"]
 
 
 gem_group :development, :test do
@@ -46,4 +46,3 @@ run "bundle install"
 rake "db:create"
 generate "calagator:install", (generating_dummy && "--dummy")
 generate "sunspot_rails:install"
-

--- a/spec/controllers/calagator/events_controller_spec.rb
+++ b/spec/controllers/calagator/events_controller_spec.rb
@@ -32,8 +32,8 @@ describe EventsController, :type => :controller do
 
       describe "with events" do
         before do
-          FactoryGirl.create(:event, :with_venue)
-          FactoryGirl.create(:event, :with_venue)
+          FactoryBot.create(:event, :with_venue)
+          FactoryBot.create(:event, :with_venue)
 
           get :index, :format => "xml"
 
@@ -77,7 +77,7 @@ describe EventsController, :type => :controller do
 
       describe "with events" do
         before do
-          @event = FactoryGirl.create(:event, :with_venue)
+          @event = FactoryBot.create(:event, :with_venue)
           @venue = @event.venue
 
           get :index, :format => "json"
@@ -123,8 +123,8 @@ describe EventsController, :type => :controller do
 
       describe "with events" do
         before do
-          FactoryGirl.create(:event, :with_venue)
-          FactoryGirl.create(:event, :with_venue)
+          FactoryBot.create(:event, :with_venue)
+          FactoryBot.create(:event, :with_venue)
 
           get :index, :format => "atom"
 
@@ -173,8 +173,8 @@ describe EventsController, :type => :controller do
 
       describe "with events" do
         before do
-          @current_event = FactoryGirl.create(:event, :start_time => today + 1.hour)
-          @past_event = FactoryGirl.create(:event, :start_time => today - 1.hour)
+          @current_event = FactoryBot.create(:event, :start_time => today + 1.hour)
+          @past_event = FactoryBot.create(:event, :start_time => today - 1.hour)
 
           get :index, :format => "ics"
         end
@@ -286,7 +286,7 @@ describe EventsController, :type => :controller do
     end
 
     it "should redirect from a duplicate event to its master" do
-      master = FactoryGirl.create(:event, id: 4321)
+      master = FactoryBot.create(:event, id: 4321)
       event = Event.new(:start_time => now, :duplicate_of => master)
       expect(Event).to receive(:find).and_return(event)
 
@@ -316,8 +316,8 @@ describe EventsController, :type => :controller do
         "end_time"       => "",
         "start_time"     => ""
       }.with_indifferent_access
-      @venue = FactoryGirl.build(:venue)
-      @event = FactoryGirl.build(:event, :venue => @venue)
+      @venue = FactoryBot.build(:venue)
+      @event = FactoryBot.build(:event, :venue => @venue)
     end
 
     describe "#new" do
@@ -358,7 +358,7 @@ describe EventsController, :type => :controller do
 
       it "should associate a venue by id when both an id and a name are provided" do
         @venue.save!
-        @venue2 = FactoryGirl.create(:venue)
+        @venue2 = FactoryBot.create(:venue)
         @params[:event][:venue_id] = @venue.id.to_s
         @params[:venue_name] = @venue2.title
         post :create, @params
@@ -422,7 +422,7 @@ describe EventsController, :type => :controller do
       end
 
       it "should create an event for an existing venue" do
-        venue = FactoryGirl.create(:venue)
+        venue = FactoryBot.create(:venue)
 
         post :create,
           :start_time => now.strftime("%Y-%m-%d"),
@@ -447,7 +447,7 @@ describe EventsController, :type => :controller do
 
     describe "#update" do
       before(:each) do
-        @event = FactoryGirl.create(:event, :with_venue, id: 42)
+        @event = FactoryBot.create(:event, :with_venue, id: 42)
         @venue = @event.venue
         @params.merge!(id: 42)
       end
@@ -465,7 +465,7 @@ describe EventsController, :type => :controller do
       end
 
       it "should associate a venue based on a given venue id" do
-        @venue = FactoryGirl.create(:venue)
+        @venue = FactoryBot.create(:venue)
         @params[:event][:venue_id] = @venue.id.to_s
         put "update", @params
         expect(@event.reload.venue).to eq(@venue)
@@ -473,7 +473,7 @@ describe EventsController, :type => :controller do
       end
 
       it "should associate a venue based on a given venue name" do
-        @venue = FactoryGirl.create(:venue)
+        @venue = FactoryBot.create(:venue)
         @params[:venue_name] = @venue.title
         put "update", @params
         expect(@event.reload.venue).to eq(@venue)
@@ -481,8 +481,8 @@ describe EventsController, :type => :controller do
       end
 
       it "should associate a venue by id when both an id and a name are provided" do
-        @venue = FactoryGirl.create(:venue)
-        @venue2 = FactoryGirl.create(:venue)
+        @venue = FactoryBot.create(:venue)
+        @venue2 = FactoryBot.create(:venue)
         @params[:event][:venue_id] = @venue.id.to_s
         @params[:venue_name] = @venue2.title
         put "update", @params
@@ -537,7 +537,7 @@ describe EventsController, :type => :controller do
 
     describe "#clone" do
       before do
-        @event = FactoryGirl.create(:event)
+        @event = FactoryBot.create(:event)
 
         allow(Event).to receive(:find).and_return(@event)
 
@@ -578,11 +578,11 @@ describe EventsController, :type => :controller do
       render_views
 
       it "should find current duplicates and not past duplicates" do
-        current_master = FactoryGirl.create(:event, :title => "Current")
-        current_duplicate = FactoryGirl.create(:event, :title => current_master.title)
+        current_master = FactoryBot.create(:event, :title => "Current")
+        current_duplicate = FactoryBot.create(:event, :title => current_master.title)
 
-        past_master = FactoryGirl.create(:event, :title => "Past", :start_time => now - 2.days)
-        past_duplicate = FactoryGirl.create(:event, :title => past_master.title, :start_time => now - 1.day)
+        past_master = FactoryBot.create(:event, :title => "Past", :start_time => now - 2.days)
+        past_duplicate = FactoryBot.create(:event, :title => past_master.title, :start_time => now - 1.day)
 
         get 'duplicates', :type => 'title'
 
@@ -597,8 +597,8 @@ describe EventsController, :type => :controller do
       end
 
       it "should redirect duplicate events to their master" do
-        event_master = FactoryGirl.create(:event)
-        event_duplicate = FactoryGirl.create(:event)
+        event_master = FactoryBot.create(:event)
+        event_duplicate = FactoryBot.create(:event)
 
         get 'show', :id => event_duplicate.id
         expect(response).not_to be_redirect
@@ -629,9 +629,9 @@ describe EventsController, :type => :controller do
     describe "when returning results" do
       render_views
 
-      let!(:current_event) { FactoryGirl.create(:event, :with_venue, title: "MyQuery") }
-      let!(:current_event_2) { FactoryGirl.create(:event, :with_venue, description: "WOW myquery!") }
-      let!(:past_event) { FactoryGirl.create(:event, :with_venue, title: "old myquery") }
+      let!(:current_event) { FactoryBot.create(:event, :with_venue, title: "MyQuery") }
+      let!(:current_event_2) { FactoryBot.create(:event, :with_venue, description: "WOW myquery!") }
+      let!(:past_event) { FactoryBot.create(:event, :with_venue, title: "old myquery") }
 
       describe "in HTML format" do
         before do
@@ -749,7 +749,7 @@ describe EventsController, :type => :controller do
 
   describe "#destroy" do
     it "should destroy events" do
-      event = FactoryGirl.build(:event)
+      event = FactoryBot.build(:event)
       expect(event).to receive(:destroy)
       expect(Event).to receive(:find).and_return(event)
 
@@ -758,7 +758,7 @@ describe EventsController, :type => :controller do
     end
 
     it "should not allow a user to destroy a locked event" do
-      event = FactoryGirl.create(:event)
+      event = FactoryBot.create(:event)
       event.lock_editing!
 
       delete 'destroy', :id => event.id

--- a/spec/controllers/calagator/venues_controller_spec.rb
+++ b/spec/controllers/calagator/venues_controller_spec.rb
@@ -9,8 +9,8 @@ describe VenuesController, :type => :controller do
   render_views
 
   context "concerning duplicates" do
-    let!(:venue_master) { FactoryGirl.create(:venue) }
-    let!(:venue_duplicate) { FactoryGirl.create(:venue, duplicate_of: venue_master) }
+    let!(:venue_master) { FactoryBot.create(:venue) }
+    let!(:venue_duplicate) { FactoryBot.create(:venue, duplicate_of: venue_master) }
 
     it "redirects duplicate venues to their master" do
       get 'show', id: venue_duplicate.id
@@ -44,7 +44,7 @@ describe VenuesController, :type => :controller do
 
   describe "when creating venues" do
     it "should redirect to the newly created venue" do
-      post :create, venue: FactoryGirl.attributes_for(:venue)
+      post :create, venue: FactoryBot.attributes_for(:venue)
       expect(response).to redirect_to(assigns(:venue))
     end
 
@@ -56,17 +56,17 @@ describe VenuesController, :type => :controller do
 
   describe "when updating venues" do
     before do
-      @venue = FactoryGirl.create(:venue)
+      @venue = FactoryBot.create(:venue)
     end
 
     it "should redirect to the updated venue" do
-      put :update, id: @venue.id, venue: FactoryGirl.attributes_for(:venue)
+      put :update, id: @venue.id, venue: FactoryBot.attributes_for(:venue)
       expect(response).to redirect_to(@venue)
     end
 
     it "should redirect to any associated event" do
-      @event = FactoryGirl.create(:event, venue: @venue)
-      put :update, id: @venue.id, from_event: @event.id, venue: FactoryGirl.attributes_for(:venue)
+      @event = FactoryBot.create(:event, venue: @venue)
+      put :update, id: @venue.id, from_event: @event.id, venue: FactoryBot.attributes_for(:venue)
       expect(response).to redirect_to(@event)
     end
 
@@ -86,7 +86,7 @@ describe VenuesController, :type => :controller do
 
   describe "when rendering the edit venue page" do
     it "passes the template the specified venue" do
-      @venue = FactoryGirl.create(:venue)
+      @venue = FactoryBot.create(:venue)
       get :edit, id: @venue.id
       expect(assigns[:venue]).to eq(@venue)
     end
@@ -94,9 +94,9 @@ describe VenuesController, :type => :controller do
 
   describe "when rendering the map page" do
     before do
-      @open_venue = FactoryGirl.create(:venue)
-      @closed_venue = FactoryGirl.create(:venue, closed: true)
-      @duplicate_venue = FactoryGirl.create(:venue, duplicate_of: @open_venue)
+      @open_venue = FactoryBot.create(:venue)
+      @closed_venue = FactoryBot.create(:venue, closed: true)
+      @duplicate_venue = FactoryBot.create(:venue, duplicate_of: @open_venue)
     end
 
     it "only shows open non-duplicate venues" do
@@ -107,7 +107,7 @@ describe VenuesController, :type => :controller do
 
   describe "when rendering the venues index" do
     before do
-      @venues = [FactoryGirl.create(:venue), FactoryGirl.create(:venue)]
+      @venues = [FactoryBot.create(:venue), FactoryBot.create(:venue)]
     end
 
     it "should assign the search object to @search" do
@@ -140,7 +140,7 @@ describe VenuesController, :type => :controller do
     describe "in JSON format" do
       describe "with events" do
         before do
-          @venue = FactoryGirl.build(:venue, :id => 123)
+          @venue = FactoryBot.build(:venue, :id => 123)
           allow(Venue).to receive(:find).and_return(@venue)
         end
 
@@ -159,9 +159,9 @@ describe VenuesController, :type => :controller do
     describe "in HTML format" do
       describe "venue with future and past events" do
         before do
-          @venue = FactoryGirl.create(:venue)
-          @future_event = FactoryGirl.create(:event, :venue => @venue)
-          @past_event = FactoryGirl.create(:event, :venue => @venue,
+          @venue = FactoryBot.create(:venue)
+          @future_event = FactoryBot.create(:event, :venue => @venue)
+          @past_event = FactoryBot.create(:event, :venue => @venue,
             :start_time => Time.now - 1.week + 1.hour,
             :end_time => Time.now - 1.week + 2.hours)
 
@@ -185,9 +185,9 @@ describe VenuesController, :type => :controller do
 
     describe "as an iCalendar" do
       before do
-        @venue = FactoryGirl.create(:venue)
-        @future_event = FactoryGirl.create(:event, :venue => @venue, :start_time => today + 1.hour)
-        @past_event = FactoryGirl.create(:event, :venue => @venue, :start_time => today - 1.hour)
+        @venue = FactoryBot.create(:venue)
+        @future_event = FactoryBot.create(:event, :venue => @venue, :start_time => today + 1.hour)
+        @past_event = FactoryBot.create(:event, :venue => @venue, :start_time => today - 1.hour)
 
         get :show, :id => @venue.to_param, :format => "ics"
       end
@@ -214,7 +214,7 @@ describe VenuesController, :type => :controller do
   describe "DELETE" do
     describe "when deleting a venue without events" do
       before do
-        @venue = FactoryGirl.create(:venue)
+        @venue = FactoryBot.create(:venue)
       end
 
       shared_examples_for "destroying a Venue record without events" do
@@ -256,7 +256,7 @@ describe VenuesController, :type => :controller do
 
     describe "when deleting a venue with events" do
       before do
-        @event = FactoryGirl.create(:event, :with_venue)
+        @event = FactoryBot.create(:event, :with_venue)
         @venue = @event.venue
       end
 

--- a/spec/controllers/calagator/versions_controller_spec.rb
+++ b/spec/controllers/calagator/versions_controller_spec.rb
@@ -31,7 +31,7 @@ describe VersionsController, :type => :controller do
       @update_title = "myevent v2"
       @final_title = "myevent v3"
 
-      @event = FactoryGirl.create(:event, :title => @create_title)
+      @event = FactoryBot.create(:event, :title => @create_title)
 
       @event.title = @update_title
       @event.save!

--- a/spec/controllers/squash_many_duplicates_examples.rb
+++ b/spec/controllers/squash_many_duplicates_examples.rb
@@ -1,8 +1,8 @@
 shared_examples "#squash_many_duplicates" do |model|
   before do
-    @master = FactoryGirl.create(model, title: "master")
-    @dup1 = FactoryGirl.create(model, title: "dup1")
-    @dup2 = FactoryGirl.create(model, title: "dup2")
+    @master = FactoryBot.create(model, title: "master")
+    @dup1 = FactoryBot.create(model, title: "dup1")
+    @dup2 = FactoryBot.create(model, title: "dup2")
   end
 
   context "happy path" do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,6 +1,6 @@
 require "faker"
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :venue, class: Calagator::Venue do
     sequence(:title) { |n| "Venue #{n}" }
     sequence(:description) { |n| "Description of Venue #{n}." }
@@ -15,9 +15,9 @@ FactoryGirl.define do
     sequence(:email) { |n| "info@venue#{n}.com" }
     sequence(:telephone) { |n| "(#{n}#{n}#{n}) #{n}#{n}#{n}-#{n}#{n}#{n}#{n}" }
     sequence(:url) { |n| "http://#{n}.com" }
-    closed false
-    wifi true
-    access_notes "Access permitted."
+    closed { false }
+    wifi { true }
+    access_notes { "Access permitted." }
     after(:create) { Sunspot.commit if Calagator::Venue::SearchEngine.kind == :sunspot }
 
     trait :with_multiple_tags do
@@ -42,7 +42,7 @@ FactoryGirl.define do
 
     trait :with_source do
       association :source
-      sequence(:description) do |n| 
+      sequence(:description) do |n|
         "Description of Event #{n}.\n
         http://test.com\n
         http://example.com\n

--- a/spec/helpers/calagator/application_helper_spec.rb
+++ b/spec/helpers/calagator/application_helper_spec.rb
@@ -32,7 +32,7 @@ describe ApplicationHelper, :type => :helper do
 
   describe "#datestamp" do
     it "constructs a sentence describing the item's history" do
-      event = FactoryGirl.create(:event, created_at: "2010-01-01", updated_at: "2010-01-02")
+      event = FactoryBot.create(:event, created_at: "2010-01-01", updated_at: "2010-01-02")
       event.create_source! title: "google", url: "http://google.com"
       allow(event.source).to receive_messages id: 1
       expect(helper.datestamp(event)).to eq(

--- a/spec/helpers/calagator/events_helper_spec.rb
+++ b/spec/helpers/calagator/events_helper_spec.rb
@@ -136,20 +136,20 @@ describe EventsHelper, :type => :helper do
 
   describe "#tweet_text" do
     it "contructs a tweet" do
-      event = FactoryGirl.create(:event,
+      event = FactoryBot.create(:event,
         title: "hip and/or hop",
         start_time: "2010-01-01 12:00:00",
         end_time: "2010-01-02 12:00:00")
-      event.venue = FactoryGirl.create(:venue, title: "holocene")
+      event.venue = FactoryBot.create(:venue, title: "holocene")
       expect(tweet_text(event)).to eq("hip and/or hop - 12:00PM 01.01.2010 @ holocene")
     end
 
     it "crops it at 140 characters" do
-      event = FactoryGirl.create(:event,
+      event = FactoryBot.create(:event,
         title: "hip and/or hop, hip and/or hop, hip and/or hop, hip and/or hop, hip and/or hop, hip and/or hop",
         start_time: "2010-01-01 12:00:00",
         end_time: "2010-01-02 12:00:00")
-      event.venue = FactoryGirl.create(:venue, title: "holocene")
+      event.venue = FactoryBot.create(:venue, title: "holocene")
       expect(tweet_text(event)).to eq("hip and/or hop, hip and/or hop, hip and/or hop, hip and/or hop, hip and/or hop, h... - 12:00PM 01.01.2010 @ holocene")
     end
   end

--- a/spec/helpers/calagator/tags_helper_spec.rb
+++ b/spec/helpers/calagator/tags_helper_spec.rb
@@ -5,7 +5,7 @@ module Calagator
 describe TagsHelper, type: :helper do
   describe "#tag_links_for" do
     it "renders tag links for the supplied model" do
-      event = FactoryGirl.create(:event, tag_list: %w(b a))
+      event = FactoryBot.create(:event, tag_list: %w(b a))
       expect(tag_links_for(event)).to match_dom_of \
         %(<a href="/events/tag/a" class="p-category">a</a>, ) +
         %(<a href="/events/tag/b" class="p-category">b</a>)
@@ -14,8 +14,8 @@ describe TagsHelper, type: :helper do
 
   describe "#display_tag_icons" do
     before do
-      @event = FactoryGirl.create(:event, :tag_list => ['ruby', 'pizza'])
-      @event2 = FactoryGirl.create(:event, :tag_list => ['no_image', 'also_no_image'])
+      @event = FactoryBot.create(:event, :tag_list => ['ruby', 'pizza'])
+      @event2 = FactoryBot.create(:event, :tag_list => ['no_image', 'also_no_image'])
       @untagged_event = Event.new
     end
 

--- a/spec/models/calagator/event/browse_spec.rb
+++ b/spec/models/calagator/event/browse_spec.rb
@@ -94,21 +94,21 @@ module Calagator
       let(:end_time) { "05:00 pm" }
 
       let!(:before) do
-        FactoryGirl.create(:event,
+        FactoryBot.create(:event,
                            title: "before",
                            start_time: Time.zone.parse("10:00"),
                            end_time: Time.zone.parse("14:00"))
       end
 
       let!(:after) do
-        FactoryGirl.create(:event,
+        FactoryBot.create(:event,
                            title: "after",
                            start_time: Time.zone.parse("14:00"),
                            end_time: Time.zone.parse("18:00"))
       end
 
       let!(:within) do
-        FactoryGirl.create(:event,
+        FactoryBot.create(:event,
                            title: "within",
                            start_time: Time.zone.parse("13:00"),
                            end_time: Time.zone.parse("14:00"))
@@ -147,27 +147,27 @@ module Calagator
 
     describe "when ordering" do
       it "defaults to order by start time" do
-        event1 = FactoryGirl.create(:event, start_time: Time.zone.parse("3003-01-01"))
-        event2 = FactoryGirl.create(:event, start_time: Time.zone.parse("3002-01-01"))
-        event3 = FactoryGirl.create(:event, start_time: Time.zone.parse("3001-01-01"))
+        event1 = FactoryBot.create(:event, start_time: Time.zone.parse("3003-01-01"))
+        event2 = FactoryBot.create(:event, start_time: Time.zone.parse("3002-01-01"))
+        event3 = FactoryBot.create(:event, start_time: Time.zone.parse("3001-01-01"))
 
         browse = Event::Browse.new
         expect(browse.events).to eq([event3, event2, event1])
       end
 
       it "can order by event name" do
-        event1 = FactoryGirl.create(:event, title: "CU there")
-        event2 = FactoryGirl.create(:event, title: "Be there")
-        event3 = FactoryGirl.create(:event, title: "An event")
+        event1 = FactoryBot.create(:event, title: "CU there")
+        event2 = FactoryBot.create(:event, title: "Be there")
+        event3 = FactoryBot.create(:event, title: "An event")
 
         browse = Event::Browse.new(order: "name")
         expect(browse.events).to eq([event3, event2, event1])
       end
 
       it "can order by venue name" do
-        event1 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "C venue"))
-        event2 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "B venue"))
-        event3 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "A venue"))
+        event1 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "C venue"))
+        event2 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "B venue"))
+        event3 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "A venue"))
 
         browse = Event::Browse.new(order: "venue")
         expect(browse.events).to eq([event3, event2, event1])

--- a/spec/models/calagator/event/cloner_spec.rb
+++ b/spec/models/calagator/event/cloner_spec.rb
@@ -5,7 +5,7 @@ module Calagator
 describe Event::Cloner do
   describe "when cloning" do
     let :original do
-      FactoryGirl.build(:event,
+      FactoryBot.build(:event,
         :id => 42,
         :start_time => Time.zone.parse("2008-01-19 10:00:00"),
         :end_time => Time.zone.parse("2008-01-19 17:00:00"),

--- a/spec/models/calagator/event/overview_spec.rb
+++ b/spec/models/calagator/event/overview_spec.rb
@@ -13,63 +13,63 @@ describe Event::Overview, :type => :model do
 
     describe "#today" do
       it "should include events that started before today and end after today" do
-        event = FactoryGirl.create(:event, start_time: @yesterday, end_time: @tomorrow)
+        event = FactoryBot.create(:event, start_time: @yesterday, end_time: @tomorrow)
         expect(subject.today).to include event
       end
 
       it "should include events that started earlier today" do
-        event = FactoryGirl.create(:event, start_time: @today_midnight)
+        event = FactoryBot.create(:event, start_time: @today_midnight)
         expect(subject.today).to include event
       end
 
       it "should not include events that ended before today" do
-        event = FactoryGirl.create(:event, start_time: @yesterday, end_time: @yesterday.end_of_day)
+        event = FactoryBot.create(:event, start_time: @yesterday, end_time: @yesterday.end_of_day)
         expect(subject.today).not_to include event
       end
 
       it "should not include events that start tomorrow" do
-        event = FactoryGirl.create(:event, start_time: @tomorrow)
+        event = FactoryBot.create(:event, start_time: @tomorrow)
         expect(subject.today).not_to include event
       end
 
       it "should not include events that ended at midnight today" do
-        event = FactoryGirl.create(:event, start_time: @yesterday, end_time: @today_midnight)
+        event = FactoryBot.create(:event, start_time: @yesterday, end_time: @today_midnight)
         expect(subject.today).not_to include event
       end
     end
 
     describe "#tomorrow" do
       it "should include events that start tomorrow" do
-        event = FactoryGirl.create(:event, start_time: @tomorrow)
+        event = FactoryBot.create(:event, start_time: @tomorrow)
         expect(subject.tomorrow).to include event
       end
 
       it "should not include events that start after tomorrow" do
-        event = FactoryGirl.create(:event, start_time: @day_after_tomorrow)
+        event = FactoryBot.create(:event, start_time: @day_after_tomorrow)
         expect(subject.tomorrow).not_to include event
       end
     end
 
     describe "#later" do
       it "should include events that start after tomorrow" do
-        event = FactoryGirl.create(:event, start_time: @day_after_tomorrow)
+        event = FactoryBot.create(:event, start_time: @day_after_tomorrow)
         expect(subject.later).to include event
       end
 
       it "should not include events that start after two weeks" do
-        event = FactoryGirl.create(:event, start_time: 2.weeks.from_now)
+        event = FactoryBot.create(:event, start_time: 2.weeks.from_now)
         expect(subject.later).not_to include event
       end
     end
 
     describe "#more" do
       it "should provide an event if there are events past the future cutoff" do
-        event = FactoryGirl.create(:event, start_time: 2.weeks.from_now)
+        event = FactoryBot.create(:event, start_time: 2.weeks.from_now)
         expect(subject.more).to eq(event)
       end
 
       it "should be nil if there are no events past the future cutoff" do
-        event = FactoryGirl.create(:event, start_time: 2.weeks.from_now - 1.day)
+        event = FactoryBot.create(:event, start_time: 2.weeks.from_now - 1.day)
         expect(subject.more).to be_blank
       end
     end

--- a/spec/models/calagator/event_search_spec.rb
+++ b/spec/models/calagator/event_search_spec.rb
@@ -5,90 +5,90 @@ module Calagator
 describe Event, :type => :model do
   shared_examples_for "#search" do
     it "returns everything when searching by empty string" do
-      event1 = FactoryGirl.create(:event)
-      event2 = FactoryGirl.create(:event)
+      event1 = FactoryBot.create(:event)
+      event2 = FactoryBot.create(:event)
       expect(Event.search("")).to match_array([event1, event2])
     end
 
     it "searches event titles by substring" do
-      event1 = FactoryGirl.create(:event, title: "wtfbbq")
-      event2 = FactoryGirl.create(:event, title: "zomg!")
+      event1 = FactoryBot.create(:event, title: "wtfbbq")
+      event2 = FactoryBot.create(:event, title: "zomg!")
       expect(Event.search("zomg")).to eq([event2])
     end
 
     it "searches event descriptions by substring" do
-      event1 = FactoryGirl.create(:event, description: "wtfbbq")
-      event2 = FactoryGirl.create(:event, description: "zomg!")
+      event1 = FactoryBot.create(:event, description: "wtfbbq")
+      event2 = FactoryBot.create(:event, description: "zomg!")
       expect(Event.search("zomg")).to eq([event2])
     end
 
     it "searches event tags by exact match" do
-      event1 = FactoryGirl.create(:event, tag_list: ["wtf", "bbq", "zomg"])
-      event2 = FactoryGirl.create(:event, tag_list: ["wtf", "bbq", "omg"])
+      event1 = FactoryBot.create(:event, tag_list: ["wtf", "bbq", "zomg"])
+      event2 = FactoryBot.create(:event, tag_list: ["wtf", "bbq", "omg"])
       expect(Event.search("omg")).to eq([event2])
     end
 
     it "does not search multiple terms" do
-      event1 = FactoryGirl.create(:event, title: "wtf")
-      event2 = FactoryGirl.create(:event, title: "zomg!")
-      event3 = FactoryGirl.create(:event, title: "bbq")
+      event1 = FactoryBot.create(:event, title: "wtf")
+      event2 = FactoryBot.create(:event, title: "zomg!")
+      event3 = FactoryBot.create(:event, title: "bbq")
       expect(Event.search("wtf zomg")).to match_array([])
     end
 
     it "searches case-insensitively" do
-      event1 = FactoryGirl.create(:event, title: "WTFBBQ")
-      event2 = FactoryGirl.create(:event, title: "ZOMG!")
+      event1 = FactoryBot.create(:event, title: "WTFBBQ")
+      event2 = FactoryBot.create(:event, title: "ZOMG!")
       expect(Event.search("zomg")).to eq([event2])
     end
 
     it "sorts by start time descending" do
-      event2 = FactoryGirl.create(:event, start_time: 1.day.ago)
-      event1 = FactoryGirl.create(:event, start_time: 1.day.from_now)
+      event2 = FactoryBot.create(:event, start_time: 1.day.ago)
+      event1 = FactoryBot.create(:event, start_time: 1.day.from_now)
       expect(Event.search("")).to eq([event1, event2])
     end
 
     it "can sort by event title" do
-      event2 = FactoryGirl.create(:event, title: "zomg")
-      event1 = FactoryGirl.create(:event, title: "omg")
+      event2 = FactoryBot.create(:event, title: "zomg")
+      event1 = FactoryBot.create(:event, title: "omg")
       expect(Event.search("", order: "name")).to eq([event1, event2])
     end
 
     it "can sort by venue title" do
-      event2 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "zomg"))
-      event1 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "omg"))
+      event2 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "zomg"))
+      event1 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "omg"))
       expect(Event.search("", order: "venue")).to eq([event1, event2])
     end
 
     it "can sort by start date" do
-      event2 = FactoryGirl.create(:event, start_time: 1.year.ago)
-      event1 = FactoryGirl.create(:event, start_time: 1.year.from_now)
+      event2 = FactoryBot.create(:event, start_time: 1.year.ago)
+      event1 = FactoryBot.create(:event, start_time: 1.year.from_now)
       expect(Event.search("", order: "date")).to eq([event1, event2])
     end
 
     it "can limit to current and upcoming events" do
-      event1 = FactoryGirl.create(:event, start_time: 1.year.ago, end_time: 1.year.ago + 1.hour)
-      event2 = FactoryGirl.create(:event, start_time: 1.hour.ago, end_time: 1.hour.from_now)
-      event3 = FactoryGirl.create(:event, start_time: 1.year.from_now, end_time: 1.year.from_now + 1.hour)
+      event1 = FactoryBot.create(:event, start_time: 1.year.ago, end_time: 1.year.ago + 1.hour)
+      event2 = FactoryBot.create(:event, start_time: 1.hour.ago, end_time: 1.hour.from_now)
+      event3 = FactoryBot.create(:event, start_time: 1.year.from_now, end_time: 1.year.from_now + 1.hour)
       expect(Event.search("", skip_old: true)).to eq([event3, event2])
     end
 
     it "can limit number of events" do
-      2.times { FactoryGirl.create(:event) }
+      2.times { FactoryBot.create(:event) }
       expect(Event.search("", limit: 1).count).to eq(1)
     end
 
     it "limit applies to current and past queries separately" do
-      event1 = FactoryGirl.create(:event, title: "omg", start_time: 1.year.ago)
-      event2 = FactoryGirl.create(:event, title: "omg", start_time: 1.year.ago)
-      event3 = FactoryGirl.create(:event, title: "omg", start_time: 1.year.from_now)
-      event4 = FactoryGirl.create(:event, title: "omg", start_time: 1.year.from_now)
+      event1 = FactoryBot.create(:event, title: "omg", start_time: 1.year.ago)
+      event2 = FactoryBot.create(:event, title: "omg", start_time: 1.year.ago)
+      event3 = FactoryBot.create(:event, title: "omg", start_time: 1.year.from_now)
+      event4 = FactoryBot.create(:event, title: "omg", start_time: 1.year.from_now)
       expect(Event.search("omg", limit: 1).to_a.count).to eq(2)
     end
 
     it "ANDs terms together to narrow search results" do
-      event1 = FactoryGirl.create(:event, title: "women who hack")
-      event2 = FactoryGirl.create(:event, title: "women who bike")
-      event3 = FactoryGirl.create(:event, title: "omg")
+      event1 = FactoryBot.create(:event, title: "women who hack")
+      event2 = FactoryBot.create(:event, title: "women who bike")
+      event3 = FactoryBot.create(:event, title: "omg")
       expect(Event.search("women who hack")).to eq([event1])
     end
   end
@@ -99,8 +99,8 @@ describe Event, :type => :model do
     it_should_behave_like "#search"
 
     it "searches event urls by substring" do
-      event1 = FactoryGirl.create(:event, url: "http://example.com/wtfbbq.html")
-      event2 = FactoryGirl.create(:event, url: "http://example.com/zomg.html")
+      event1 = FactoryBot.create(:event, url: "http://example.com/wtfbbq.html")
+      event2 = FactoryBot.create(:event, url: "http://example.com/zomg.html")
       expect(Event.search("zomg")).to eq([event2])
     end
 

--- a/spec/models/calagator/event_spec.rb
+++ b/spec/models/calagator/event_spec.rb
@@ -41,15 +41,15 @@ describe Event, :type => :model do
 
   describe "when checking time status" do
     it "should be old if event ended before today" do
-      expect(FactoryGirl.build(:event, start_time: 2.days.ago, end_time: 1.day.ago)).to be_old
+      expect(FactoryBot.build(:event, start_time: 2.days.ago, end_time: 1.day.ago)).to be_old
     end
 
     it "should be current if event is happening today" do
-      expect(FactoryGirl.build(:event, start_time: 1.hour.from_now)).to be_current
+      expect(FactoryBot.build(:event, start_time: 1.hour.from_now)).to be_current
     end
 
     it "should be ongoing if it began before today but ends today or later" do
-      expect(FactoryGirl.build(:event, start_time: 1.day.ago, end_time: 1.day.from_now)).to be_ongoing
+      expect(FactoryBot.build(:event, start_time: 1.day.ago, end_time: 1.day.from_now)).to be_ongoing
     end
   end
 
@@ -284,9 +284,9 @@ describe Event, :type => :model do
 
   describe ".search_tag" do
     before do
-      @c = FactoryGirl.create(:event, title: "c", tag_list: ["tag", "wtf"], start_time: 3.minutes.ago)
-      @b = FactoryGirl.create(:event, title: "b", tag_list: ["omg", "wtf"], start_time: 2.minutes.ago)
-      @a = FactoryGirl.create(:event, title: "a", tag_list: ["tag", "omg"], start_time: 1.minutes.ago)
+      @c = FactoryBot.create(:event, title: "c", tag_list: ["tag", "wtf"], start_time: 3.minutes.ago)
+      @b = FactoryBot.create(:event, title: "b", tag_list: ["omg", "wtf"], start_time: 2.minutes.ago)
+      @a = FactoryBot.create(:event, title: "a", tag_list: ["tag", "omg"], start_time: 1.minutes.ago)
     end
 
     it "finds events with the given tag" do
@@ -445,27 +445,27 @@ describe Event, :type => :model do
   describe "when ordering" do
     describe "with .ordered_by_ui_field" do
       it "defaults to order by start time" do
-        event1 = FactoryGirl.create(:event, start_time: Time.zone.parse("2003-01-01"))
-        event2 = FactoryGirl.create(:event, start_time: Time.zone.parse("2002-01-01"))
-        event3 = FactoryGirl.create(:event, start_time: Time.zone.parse("2001-01-01"))
+        event1 = FactoryBot.create(:event, start_time: Time.zone.parse("2003-01-01"))
+        event2 = FactoryBot.create(:event, start_time: Time.zone.parse("2002-01-01"))
+        event3 = FactoryBot.create(:event, start_time: Time.zone.parse("2001-01-01"))
 
         events = Event.ordered_by_ui_field(nil)
         expect(events).to eq([event3, event2, event1])
       end
 
       it "can order by event name" do
-        event1 = FactoryGirl.create(:event, title: "CU there")
-        event2 = FactoryGirl.create(:event, title: "Be there")
-        event3 = FactoryGirl.create(:event, title: "An event")
+        event1 = FactoryBot.create(:event, title: "CU there")
+        event2 = FactoryBot.create(:event, title: "Be there")
+        event3 = FactoryBot.create(:event, title: "An event")
 
         events = Event.ordered_by_ui_field("name")
         expect(events).to eq([event3, event2, event1])
       end
 
       it "can order by venue name" do
-        event1 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "C venue"))
-        event2 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "B venue"))
-        event3 = FactoryGirl.create(:event, venue: FactoryGirl.create(:venue, title: "A venue"))
+        event1 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "C venue"))
+        event2 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "B venue"))
+        event3 = FactoryBot.create(:event, venue: FactoryBot.create(:venue, title: "A venue"))
 
         events = Event.ordered_by_ui_field("venue")
         expect(events).to eq([event3, event2, event1])
@@ -475,8 +475,8 @@ describe Event, :type => :model do
 
   describe "with finding duplicates" do
     before do
-      @non_duplicate_event = FactoryGirl.create(:event)
-      @duplicate_event = FactoryGirl.create(:duplicate_event)
+      @non_duplicate_event = FactoryBot.create(:event)
+      @duplicate_event = FactoryBot.create(:duplicate_event)
       @events = [@non_duplicate_event, @duplicate_event]
     end
 
@@ -496,11 +496,11 @@ describe Event, :type => :model do
   describe "with finding duplicates (integration test)" do
     before do
       # this event should always be omitted from the results
-      past = FactoryGirl.create(:event, start_time: 1.week.ago)
+      past = FactoryBot.create(:event, start_time: 1.week.ago)
     end
 
     subject do
-      FactoryGirl.create(:event)
+      FactoryBot.create(:event)
     end
 
     it "should return future events when provided na" do
@@ -554,7 +554,7 @@ describe Event, :type => :model do
 
   describe "when squashing duplicates (integration test)" do
     before do
-      @event = FactoryGirl.create(:event, :with_venue)
+      @event = FactoryBot.create(:event, :with_venue)
       @venue = @event.venue
     end
 
@@ -643,11 +643,11 @@ describe Event, :type => :model do
     end
 
     it "should produce parsable iCal output" do
-      expect { ical_roundtrip( FactoryGirl.build(:event) ) }.not_to raise_error
+      expect { ical_roundtrip( FactoryBot.build(:event) ) }.not_to raise_error
     end
 
     it "should represent an event without an end time as a 1-hour block" do
-      event = FactoryGirl.build(:event, :start_time => now, :end_time => nil)
+      event = FactoryBot.build(:event, :start_time => now, :end_time => nil)
       expect(event.end_time).to be_blank
 
       rt = ical_roundtrip(event)
@@ -655,14 +655,14 @@ describe Event, :type => :model do
     end
 
     it "should set the appropriate end time if one is given" do
-      event = FactoryGirl.build(:event, :start_time => now, :end_time => now + 2.hours)
+      event = FactoryBot.build(:event, :start_time => now, :end_time => now + 2.hours)
 
       rt = ical_roundtrip(event)
       expect(rt.dtend - rt.dtstart).to eq 2.hours
     end
 
     describe "when comparing Event's attributes to its iCalendar output" do
-      let(:event) { FactoryGirl.build(:event, :id => 123, :created_at => now) }
+      let(:event) { FactoryBot.build(:event, :id => 123, :created_at => now) }
       let(:ical) { ical_roundtrip(event) }
 
       { :summary => :title,
@@ -689,34 +689,34 @@ describe Event, :type => :model do
     end
 
     it "should call the URL helper to generate a UID" do
-      event = FactoryGirl.build(:event)
+      event = FactoryBot.build(:event)
       expect(ical_roundtrip(event, :url_helper => lambda {|e| "UID'D!" }).uid).to eq "UID'D!"
     end
 
     it "should strip HTML from the description" do
-      event = FactoryGirl.create(:event, :description => "<blink>OMFG HTML IS TEH AWESOME</blink>")
+      event = FactoryBot.create(:event, :description => "<blink>OMFG HTML IS TEH AWESOME</blink>")
       expect(ical_roundtrip(event).description).not_to include "<blink>"
     end
 
     it "should include tags in the description" do
-      event = FactoryGirl.build(:event)
+      event = FactoryBot.build(:event)
       event.tag_list = "tags, folksonomy, categorization"
       expect(ical_roundtrip(event).description).to include event.tag_list.to_s
     end
 
     it "should leave URL blank if no URL is provided" do
-      event = FactoryGirl.build(:event, :url => nil)
+      event = FactoryBot.build(:event, :url => nil)
       expect(ical_roundtrip(event).url).to be_nil
     end
 
     it "should have Source URL if URL helper is given)" do
-      event = FactoryGirl.build(:event)
+      event = FactoryBot.build(:event)
       expect(ical_roundtrip(event, :url_helper => lambda{|e| "FAKE"} ).description).to match /FAKE/
     end
 
     it "should create multi-day entries for multi-day events" do
       time = Time.zone.now
-      event = FactoryGirl.build(:event, :start_time => time, :end_time => time + 4.days)
+      event = FactoryBot.build(:event, :start_time => time, :end_time => time + 4.days)
       parsed_event = ical_roundtrip( event )
 
       start_time = Date.current
@@ -730,13 +730,13 @@ describe Event, :type => :model do
       end
 
       it "should set an initial sequence on a new event" do
-        event = FactoryGirl.create(:event)
+        event = FactoryBot.create(:event)
         ical = event_to_ical(event)
         expect(ical.sequence).to eq 1
       end
 
       it "should increment the sequence if it is updated" do
-        event = FactoryGirl.create(:event)
+        event = FactoryBot.create(:event)
         event.update_attribute(:title, "Update 1")
         ical = event_to_ical(event)
         expect(ical.sequence).to eq 2
@@ -744,7 +744,7 @@ describe Event, :type => :model do
 
       # it "should offset the squence based the global Calagator.icalendar_sequence_offset" do
         # Calagator.should_receive(:icalendar_sequence_offset).and_return(41)
-        # event = FactoryGirl.build(:event)
+        # event = FactoryBot.build(:event)
         # ical = event_to_ical(event)
         # ical.sequence.should eq 42
       # end
@@ -752,7 +752,7 @@ describe Event, :type => :model do
 
     describe "- the headers" do
       before do
-        @data = Event::IcalRenderer.render(FactoryGirl.build(:event))
+        @data = Event::IcalRenderer.render(FactoryBot.build(:event))
       end
 
       it "should include the calendar name" do

--- a/spec/models/calagator/venue/search_spec.rb
+++ b/spec/models/calagator/venue/search_spec.rb
@@ -5,9 +5,9 @@ module Calagator
 describe Venue::Search, :type => :model do
   describe "#venues" do
     before do
-      @open_venue = FactoryGirl.create(:venue, title: 'Open Town', description: 'baz', wifi: false, tag_list: %w(foo))
-      @closed_venue = FactoryGirl.create(:venue, title: 'Closed Down', closed: true, wifi: false, tag_list: %w(bar))
-      @wifi_venue = FactoryGirl.create(:venue, title: "Internetful", wifi: true, tag_list: %w(foo bar))
+      @open_venue = FactoryBot.create(:venue, title: 'Open Town', description: 'baz', wifi: false, tag_list: %w(foo))
+      @closed_venue = FactoryBot.create(:venue, title: 'Closed Down', closed: true, wifi: false, tag_list: %w(bar))
+      @wifi_venue = FactoryBot.create(:venue, title: "Internetful", wifi: true, tag_list: %w(foo bar))
     end
 
     describe "with no parameters" do

--- a/spec/models/calagator/venue_search_spec.rb
+++ b/spec/models/calagator/venue_search_spec.rb
@@ -5,73 +5,73 @@ module Calagator
 describe Venue, :type => :model do
   shared_examples_for "#search" do
     it "returns everything when searching by empty string" do
-      venue1 = FactoryGirl.create(:venue)
-      venue2 = FactoryGirl.create(:venue)
+      venue1 = FactoryBot.create(:venue)
+      venue2 = FactoryBot.create(:venue)
       expect(Venue.search("")).to match_array([venue1, venue2])
     end
 
     it "searches venue titles by substring" do
-      venue1 = FactoryGirl.create(:venue, title: "wtfbbq")
-      venue2 = FactoryGirl.create(:venue, title: "zomg!")
+      venue1 = FactoryBot.create(:venue, title: "wtfbbq")
+      venue2 = FactoryBot.create(:venue, title: "zomg!")
       expect(Venue.search("zomg")).to eq([venue2])
     end
 
     it "searches venue descriptions by substring" do
-      venue1 = FactoryGirl.create(:venue, description: "wtfbbq")
-      venue2 = FactoryGirl.create(:venue, description: "zomg!")
+      venue1 = FactoryBot.create(:venue, description: "wtfbbq")
+      venue2 = FactoryBot.create(:venue, description: "zomg!")
       expect(Venue.search("zomg")).to eq([venue2])
     end
 
     it "searches venue tags by exact match" do
-      venue1 = FactoryGirl.create(:venue, tag_list: ["wtf", "bbq", "zomg"])
-      venue2 = FactoryGirl.create(:venue, tag_list: ["wtf", "bbq", "omg"])
+      venue1 = FactoryBot.create(:venue, tag_list: ["wtf", "bbq", "zomg"])
+      venue2 = FactoryBot.create(:venue, tag_list: ["wtf", "bbq", "omg"])
       expect(Venue.search("omg")).to eq([venue2])
     end
 
     it "searches case-insensitively" do
-      venue1 = FactoryGirl.create(:venue, title: "WTFBBQ")
-      venue2 = FactoryGirl.create(:venue, title: "ZOMG!")
+      venue1 = FactoryBot.create(:venue, title: "WTFBBQ")
+      venue2 = FactoryBot.create(:venue, title: "ZOMG!")
       expect(Venue.search("zomg")).to eq([venue2])
     end
 
     it "sorts by title" do
-      venue2 = FactoryGirl.create(:venue, title: "zomg")
-      venue1 = FactoryGirl.create(:venue, title: "omg")
+      venue2 = FactoryBot.create(:venue, title: "zomg")
+      venue1 = FactoryBot.create(:venue, title: "omg")
       expect(Venue.search("", order: "name")).to eq([venue1, venue2])
     end
 
     it "can limit to venues with wifi" do
-      venue1 = FactoryGirl.create(:venue, wifi: false)
-      venue2 = FactoryGirl.create(:venue, wifi: true)
+      venue1 = FactoryBot.create(:venue, wifi: false)
+      venue2 = FactoryBot.create(:venue, wifi: true)
       expect(Venue.search("", wifi: true)).to eq([venue2])
     end
 
     it "excludes closed venues" do
-      venue1 = FactoryGirl.create(:venue, closed: true)
-      venue2 = FactoryGirl.create(:venue, closed: false)
+      venue1 = FactoryBot.create(:venue, closed: true)
+      venue2 = FactoryBot.create(:venue, closed: false)
       expect(Venue.search("")).to eq([venue2])
     end
 
     it "can include closed venues" do
-      venue1 = FactoryGirl.create(:venue, closed: true)
-      venue2 = FactoryGirl.create(:venue, closed: false)
+      venue1 = FactoryBot.create(:venue, closed: true)
+      venue2 = FactoryBot.create(:venue, closed: false)
       expect(Venue.search("", include_closed: true)).to match_array([venue1, venue2])
     end
 
     it "can limit number of venues" do
-      2.times { FactoryGirl.create(:venue) }
+      2.times { FactoryBot.create(:venue) }
       expect(Venue.search("", limit: 1).count).to eq(1)
     end
 
     it "does not search multiple terms" do
-      venue2 = FactoryGirl.create(:venue, title: "zomg")
-      venue1 = FactoryGirl.create(:venue, title: "omg")
+      venue2 = FactoryBot.create(:venue, title: "zomg")
+      venue1 = FactoryBot.create(:venue, title: "omg")
       expect(Venue.search("zomg omg")).to eq([])
     end
 
     it "ANDs terms together to narrow search results" do
-      venue2 = FactoryGirl.create(:venue, title: "zomg omg")
-      venue1 = FactoryGirl.create(:venue, title: "zomg cats")
+      venue2 = FactoryBot.create(:venue, title: "zomg omg")
+      venue1 = FactoryBot.create(:venue, title: "zomg cats")
       expect(Venue.search("zomg omg")).to eq([venue2])
     end
 

--- a/spec/models/calagator/venue_spec.rb
+++ b/spec/models/calagator/venue_spec.rb
@@ -88,42 +88,42 @@ describe Venue, :type => :model do
 
   describe "when finding duplicates [integration test]" do
     subject! do
-      FactoryGirl.create(:venue, title: "Venue A")
+      FactoryBot.create(:venue, title: "Venue A")
     end
 
     it "should not match totally different records" do
-      FactoryGirl.create(:venue)
+      FactoryBot.create(:venue)
       expect(Venue.find_duplicates_by_type("title")).to be_empty
     end
 
     it "should not match similar records when not searching by duplicated fields" do
-      FactoryGirl.create :venue, title: subject.title
+      FactoryBot.create :venue, title: subject.title
       expect(Venue.find_duplicates_by_type("description")).to be_empty
     end
 
     it "should match similar records when searching by duplicated fields" do
-      venue = FactoryGirl.create(:venue, title: subject.title)
+      venue = FactoryBot.create(:venue, title: subject.title)
       expect(Venue.find_duplicates_by_type("title")).to eq({ [subject.title] => [subject, venue] })
     end
 
     it "should match similar records when searching by :any" do
-      venue = FactoryGirl.create(:venue, title: subject.title)
+      venue = FactoryBot.create(:venue, title: subject.title)
       expect(Venue.find_duplicates_by_type("any")).to eq({ [nil] => [subject, venue] })
     end
 
     it "should not match similar records when searching by multiple fields where not all are duplicated" do
-      FactoryGirl.create(:venue, title: subject.title)
+      FactoryBot.create(:venue, title: subject.title)
       expect(Venue.find_duplicates_by_type("title,description")).to be_empty
     end
 
     it "should match similar records when searching by multiple fields where all are duplicated" do
-      venue = FactoryGirl.create(:venue, title: subject.title, description: subject.description)
+      venue = FactoryBot.create(:venue, title: subject.title, description: subject.description)
       expect(Venue.find_duplicates_by_type("title,description")).to \
         eq({ [subject.title, subject.description] => [subject, venue] })
     end
 
     it "should not match dissimilar records when searching by :all" do
-      FactoryGirl.create(:venue)
+      FactoryBot.create(:venue)
       expect(Venue.find_duplicates_by_type("all")).to be_empty
     end
 
@@ -134,7 +134,7 @@ describe Venue, :type => :model do
     end
 
     it "should match non duplicate venues when searching by na" do
-      venue = FactoryGirl.create(:venue, title: "Venue B")
+      venue = FactoryBot.create(:venue, title: "Venue B")
       expect(Venue.find_duplicates_by_type("na")).to eq({ [nil] => [subject, venue] })
     end
   end
@@ -337,7 +337,7 @@ describe "Venue geocode addressing", :type => :model do
     end
 
     it "should create a new version after updating" do
-      venue = FactoryGirl.create :venue
+      venue = FactoryBot.create :venue
       expect(venue.versions.count).to eq 1
 
       venue.title += " (change)"
@@ -347,7 +347,7 @@ describe "Venue geocode addressing", :type => :model do
     end
 
     it "should store old content in past versions" do
-      venue = FactoryGirl.create :venue
+      venue = FactoryBot.create :venue
       original_title = venue.title
 
       venue.title += " (change)"

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -18,13 +18,13 @@ describe ActsAsTaggableOn::Tag, :type => :model do
       end
 
       it "should redirect to 'defunct' page with archive url as query param when using a defunct provider" do
-        @event = FactoryGirl.create :event, tag_list: 'upcoming:event=1234'
+        @event = FactoryBot.create :event, tag_list: 'upcoming:event=1234'
         event_date = @event.start_time.strftime("%Y%m%d")
         expect(@event.tags.last.machine_tag.url).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{event_date}/http://upcoming.yahoo.com/event/1234"
       end
 
       it "should redirect correctly for venue tags also" do
-        @venue = FactoryGirl.create :venue, tag_list: 'upcoming:venue=1234'
+        @venue = FactoryBot.create :venue, tag_list: 'upcoming:venue=1234'
         venue_date = @venue.created_at.strftime("%Y%m%d")
         expect(@venue.tags.last.machine_tag.url).to eq "http://my-calagator.org/defunct?url=https://web.archive.org/web/#{venue_date}/http://upcoming.yahoo.com/venue/1234"
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ require "rspec-activemodel-mocks"
 require "rspec/its"
 require "rspec-rails"
 require "rspec/collection_matchers"
-require "factory_girl_rails"
+require "factory_bot_rails"
 require "capybara"
 require "capybara/rspec"
 require "database_cleaner"
@@ -48,7 +48,7 @@ Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   config.use_transactional_fixtures = false
 
   config.before(:suite) do |example|


### PR DESCRIPTION
Upgraded from `factory_girl_rails` to `factory_bot_rails` at its most recent version. This mostly involved updating the gem name and replacing all instances of FactoryGirl with FactoryBot. In `factories.rb`, I also updated a few of the definitions to be dynamic instead of static to get rid of this warning:

```
DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
attributes instead by wrapping the attribute value in a block
```