### PR TITLE
Improve accessibility of add/edit event form required fields

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -40,6 +40,7 @@ These people have contributed to Calagator's design and implementation:
   * Jesse Cooke
   * Jesse Hallett
   * Joe Cohen
+  * Josh Hetrick
   * Kerri Miller
   * Kevin Scaldaferri
   * Kirsten Comandich

--- a/app/views/calagator/events/_form.html.erb
+++ b/app/views/calagator/events/_form.html.erb
@@ -15,7 +15,7 @@
 
 <%= semantic_form_for(event, :html => {:id => 'event_form', :class => 'standard_form', :novalidate => 'novalidate'}) do |f| %>
   <%= f.inputs :name => "#{'Editing: ' unless event.new_record?} <em>#{event.title}</em>".html_safe do %>
-    <%= f.input :title, label: "Event Name", input_html: { autofocus: true } %>
+    <%= f.input :title, label: "Event Name", required: true, input_html: { autofocus: true } %>
     <li class="string input required stringish" id="event_venue_title_input">
       <%= label_tag :venue_name, "Venue", :class => 'label' %>
       <%= text_field_tag 'venue_name', '', :class=> 'autocomplete', :value => !event.venue.nil? ? event.venue.title : params[:venue_name] %>
@@ -27,17 +27,21 @@
     </li>
     <li id="event_times" class='input'>
       <%= f.label :when, :class => 'label'  do -%>
-        When<abbr title="required">*</abbr>
+        When<abbr title="required" aria-hidden="true">*</abbr>
       <% end -%>
         <div class="event_start">
-          <%= text_field_tag 'start_date', format_event_date(event.start_time), :id => 'date_start', :class => 'date_picker' %>
-          <span class="at">@</span>
-          <%= text_field_tag 'start_time', format_event_time(event.start_time), :id => 'time_start', :class => 'time_picker' %>
+          <%= label_tag :date_start, "Start Date", :class => ['label', 'sr-only'] %>
+          <%= text_field_tag 'start_date', format_event_date(event.start_time), :id => 'date_start', :class => 'date_picker', required: true %>
+          <span class="at" aria-hidden="true">@</span>
+          <%= label_tag :time_start, "Start Time", :class => ['label', 'sr-only'] %>
+          <%= text_field_tag 'start_time', format_event_time(event.start_time), :id => 'time_start', :class => 'time_picker', required: true %>
         </div>
-        <span class="to">to</span>
+        <span class="to" aria-hidden="true">to</span>
         <div class="event_end">
+          <%= label_tag :date_end, "End Date", :class => ['label', 'sr-only'] %>
           <%= text_field_tag 'end_date', format_event_date(event.end_time), :id => 'date_end', :class => 'date_picker' %>
-          <span class="at">@</span>
+          <span class="at" aria-hidden="true">@</span>
+          <%= label_tag :time_end, "End Time", :class => ['label', 'sr-only'] %>
           <%= text_field_tag 'end_time', format_event_time(event.end_time), :id => 'time_end', :class => 'time_picker' %>
         </div>
         <%= f.semantic_errors :start_date, :start_time, :end_date, :end_time %>

--- a/config/initializers/formtastic.rb
+++ b/config/initializers/formtastic.rb
@@ -31,7 +31,7 @@ Formtastic::FormBuilder.all_fields_required_by_default = false
 # '<abbr title="required">*</abbr>'. In other words, if you configure formtastic.required
 # in your locale, it will replace the abbr title properly. But if you don't want to use
 # abbr tag, you can simply give a string as below
-# Formtastic::FormBuilder.required_string = "(required)"
+Formtastic::FormBuilder.required_string = proc { %{<abbr title="#{Formtastic::I18n.t(:required)}" aria-hidden="true">*</abbr>}.html_safe }
 
 # Set the string that will be appended to the labels/fieldsets which are optional
 # Defaults to an empty string ("") and also accepts procs (see required_string above)
@@ -88,6 +88,10 @@ Formtastic::FormBuilder.all_fields_required_by_default = false
 #   warning from spewing during test runs.
 #
 #   More info: https://github.com/justinfrench/formtastic/wiki/Upgrading-to-Formtastic-3.1
+
+# You can opt-in to Formtastic's use of the HTML5 `required` attribute on `<input>`, `<select>`
+# and `<textarea>` tags by setting this to true (defaults to false).
+Formtastic::FormBuilder.use_required_attribute = true
 
 require 'formtastic/version'
 


### PR DESCRIPTION
On the add/edit event form:  
* Required `input` fields now use the `required` attribute. 
* The asterisk in the required field's `label` is now a visual only cue (it will be skipped by screen readers). 
* The visible "@" and "to" labels for the date and time fields are skipped by screen readers, and more explicit, non-visible labels have been added for screen readers. 

For more background on these, see: 
* https://github.com/calagator/calagator.org/issues/30 
* https://github.com/calagator/calagator.org/issues/31