### PR TITLE
Add landmarks to improve screen reader navigation options

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,13 +15,17 @@ jobs:
   rubocop:
     name: "Run Rubocop"
     runs-on: ubuntu-latest
-    if: github.repository == 'calagator/calagator'
     steps:
       - uses: actions/checkout@master
-      - name: Rubocop Linter
-        uses: andrewmcodes/rubocop-linter-action@v3.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-ruby@v1
+      - name: Install Rubocop
+        run: gem install rubocop rubocop-performance rubocop-rails rubocop-rspec
+      - name: Rubocop
+        run: rubocop --fail-level warning
+      # - name: Rubocop Linter
+      #   uses: andrewmcodes/rubocop-linter-action@v3.1.0
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
 

--- a/app/views/calagator/events/_subnav.html.erb
+++ b/app/views/calagator/events/_subnav.html.erb
@@ -1,4 +1,4 @@
-<div id="events_subnav" class="subnav">
+<nav id="events_subnav" class="subnav" aria-label="Events">
     <ul class="clearfix">
       <li><%= link_to 'Browse events', root_url,
               :class => subnav_class_for("site", "index") %>
@@ -10,4 +10,4 @@
               :class => subnav_class_for("sources", "new") %>
       </li>
     </ul>
-</div>
+</nav>

--- a/app/views/calagator/venues/_subnav.html.erb
+++ b/app/views/calagator/venues/_subnav.html.erb
@@ -1,4 +1,4 @@
-<div id="venues_subnav" class="subnav">
+<nav id="venues_subnav" class="subnav" aria-label="Venues">
     <ul class="clearfix">
       <li><%= link_to 'Browse venues', venues_url,
               :class => subnav_class_for("venues", "index") %>
@@ -7,4 +7,4 @@
               :class => subnav_class_for("venues", "new") %>
       </li>
     </ul>
-</div>
+</nav>

--- a/app/views/layouts/calagator/_content.html.erb
+++ b/app/views/layouts/calagator/_content.html.erb
@@ -1,6 +1,6 @@
-      <div id="content">
+      <main id="content">
         <%# flash[:success] = "yay"; flash[:failure] = "meh" %>
         <%= render_flash %>
         <%= yield %>
-      </div>
+      </main>
 

--- a/app/views/layouts/calagator/_footer.html.erb
+++ b/app/views/layouts/calagator/_footer.html.erb
@@ -1,8 +1,8 @@
-      <div id="top_footer">
+      <footer id="top_footer">
         <%= URI.parse(Calagator.url).host %>
         <%= source_code_version %>
         &nbsp;
         &nbsp;
         &nbsp;
-      </div>
+      </footer>
 

--- a/app/views/layouts/calagator/_global_search.html.erb
+++ b/app/views/layouts/calagator/_global_search.html.erb
@@ -1,11 +1,13 @@
-          <%= form_tag search_events_path, :method => :get do %>
-            <div id='search_form'>
-            <label for="search_field">Search Events</label>
-            <% if request.env["HTTP_USER_AGENT"] && request.env["HTTP_USER_AGENT"].include?("Safari") %>
-              <input type="search" name="query" value="<%= @query %>" results="5" id="search_field">
-            <% else %>
-              <%= text_field_tag 'query', @query, id: 'search_field', tabindex: 1 %>
-            <% end %>
-            </div>
-          <% end -%>
+          <div role="search">
+            <%= form_tag search_events_path, :method => :get do %>
+              <div id='search_form'>
+              <label for="search_field">Search Events</label>
+              <% if request.env["HTTP_USER_AGENT"] && request.env["HTTP_USER_AGENT"].include?("Safari") %>
+                <input type="search" name="query" value="<%= @query %>" results="5" id="search_field">
+              <% else %>
+                <%= text_field_tag 'query', @query, id: 'search_field', tabindex: 1 %>
+              <% end %>
+              </div>
+            <% end -%>
+          </div>
 

--- a/app/views/layouts/calagator/_header.html.erb
+++ b/app/views/layouts/calagator/_header.html.erb
@@ -3,12 +3,12 @@
           <%= link_to Calagator.title, root_path, id: "project_title" %>
 
           <div id="top_menu">
-            <div id='app_menu'>
+            <nav id='app_menu'>
               <ul>
                   <li class='<%=link_class[:events]%>'><%= link_to "Events", events_path %></li>
                   <li class='<%=link_class[:venues]%>'><%= link_to "Venues", venues_path %></li>
               </ul>
-            </div>
+            </nav>
             <%= render partial: 'layouts/calagator/global_search' %>
           </div>
         </div>

--- a/app/views/layouts/calagator/_header.html.erb
+++ b/app/views/layouts/calagator/_header.html.erb
@@ -1,20 +1,22 @@
-      <div id="global_header">
-        <%= link_to Calagator.title, root_path, id: "project_title" %>
+      <header>
+        <div id="global_header">
+          <%= link_to Calagator.title, root_path, id: "project_title" %>
 
-        <div id="top_menu">
-          <div id='app_menu'>
-            <ul>
-                <li class='<%=link_class[:events]%>'><%= link_to "Events", events_path %></li>
-                <li class='<%=link_class[:venues]%>'><%= link_to "Venues", venues_path %></li>
-            </ul>
+          <div id="top_menu">
+            <div id='app_menu'>
+              <ul>
+                  <li class='<%=link_class[:events]%>'><%= link_to "Events", events_path %></li>
+                  <li class='<%=link_class[:venues]%>'><%= link_to "Venues", venues_path %></li>
+              </ul>
+            </div>
+            <%= render partial: 'layouts/calagator/global_search' %>
           </div>
-          <%= render partial: 'layouts/calagator/global_search' %>
         </div>
-      </div>
 
-      <% # Pick a subnav %>
+        <% # Pick a subnav %>
 
-      <%= render(:partial => 'calagator/events/subnav') if link_class[:events] == 'active' %>
-      <%= render(:partial => 'calagator/venues/subnav') if link_class[:venues] == 'active' %>
-      <%= render(:partial => 'calagator/sources/subnav') if link_class[:import] == 'active' %>
+        <%= render(:partial => 'calagator/events/subnav') if link_class[:events] == 'active' %>
+        <%= render(:partial => 'calagator/venues/subnav') if link_class[:venues] == 'active' %>
+        <%= render(:partial => 'calagator/sources/subnav') if link_class[:import] == 'active' %>
 
+      </header>

--- a/app/views/layouts/calagator/_header.html.erb
+++ b/app/views/layouts/calagator/_header.html.erb
@@ -3,7 +3,7 @@
           <%= link_to Calagator.title, root_path, id: "project_title" %>
 
           <div id="top_menu">
-            <nav id='app_menu'>
+            <nav id='app_menu' aria-label='primary'>
               <ul>
                   <li class='<%=link_class[:events]%>'><%= link_to "Events", events_path %></li>
                   <li class='<%=link_class[:venues]%>'><%= link_to "Venues", venues_path %></li>

--- a/db/migrate/20200327040656_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200327040656_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 6)
 if ActiveRecord.gem_version >= Gem::Version.new('5.0')
   class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
@@ -12,12 +14,12 @@ AddMissingIndexesOnTaggings.class_eval do
     add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
     add_index :taggings, :context unless index_exists? :taggings, :context
 
-    unless index_exists? :taggings, [:tagger_id, :tagger_type]
-      add_index :taggings, [:tagger_id, :tagger_type]
+    unless index_exists? :taggings, %i[tagger_id tagger_type]
+      add_index :taggings, %i[tagger_id tagger_type]
     end
 
-    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
-      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    unless index_exists? :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+      add_index :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,8 @@ require 'selenium-webdriver'
 require 'timecop'
 require 'webmock'
 
-if Object.const_defined? "SimpleCov"
-  SimpleCov.command_name "rspec"
+if Object.const_defined? 'SimpleCov'
+  SimpleCov.command_name 'rspec'
 end
 
 # Load support files


### PR DESCRIPTION
Adds landmarks to improve navigation options when using a screen reader or other landmark-aware tools: 

* A `header` element is used for top matter which appears on every page appears. Inside of that: 
  * `nav` elements for primary navigation and sub navigation for Events/Venues; each `nav` element has an `aria-label` to differentiate them. 
  * `role="search"` added to a wrapper around the global search controls
* `main` element used for primary page content
* `footer` element used for version info

Fixes calagator/calagator.org#33. 