### PR TITLE
Fix spec failures — Can't create Binding from C level Proc

### DIFF
--- a/app/models/calagator/event/search_engine/apache_sunspot.rb
+++ b/app/models/calagator/event/search_engine/apache_sunspot.rb
@@ -40,7 +40,7 @@ module Calagator
             text(:venue_title) { venue.try(:title) }
             string(:venue_title) { venue.try(:title) }
 
-            boolean(:duplicate, &:duplicate?)
+            boolean(:duplicate) { duplicate? }
           end
         end
 


### PR DESCRIPTION
We can't use Symbol#to_proc in Sunspot field config. Sunspot's value extractor calls #binding on the passed block, which fails with `ArgumentError: Can't create Binding from C level Proc`.