### PR TITLE
Upgrade acts-as-taggable-on depdendency to 5.x

### DIFF
--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   # When changing this Rails requirement, also update RAILS_REQUIREMENT in rails_template.rb
   s.add_dependency 'rails', '~> 4.2'
 
-  s.add_dependency 'acts-as-taggable-on', '~> 3.5'
+  s.add_dependency 'acts-as-taggable-on', '~> 5.0'
   s.add_dependency 'bluecloth', '~> 2.2'
   s.add_dependency 'font-awesome-rails', '~> 4.3'
   s.add_dependency 'formtastic', '~> 3.1'

--- a/db/migrate/20200327040656_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200327040656_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,0 +1,23 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+if ActiveRecord.gem_version >= Gem::Version.new('5.0')
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
+else
+  class AddMissingIndexesOnTaggings < ActiveRecord::Migration; end
+end
+AddMissingIndexesOnTaggings.class_eval do
+  def change
+    add_index :taggings, :tag_id unless index_exists? :taggings, :tag_id
+    add_index :taggings, :taggable_id unless index_exists? :taggings, :taggable_id
+    add_index :taggings, :taggable_type unless index_exists? :taggings, :taggable_type
+    add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
+    add_index :taggings, :context unless index_exists? :taggings, :context
+
+    unless index_exists? :taggings, [:tagger_id, :tagger_type]
+      add_index :taggings, [:tagger_id, :tagger_type]
+    end
+
+    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    end
+  end
+end


### PR DESCRIPTION
This is the last version that supports Rails 4.2