### PR TITLE
Remove GitHub Checks reporting for Rubocop

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,13 +15,17 @@ jobs:
   rubocop:
     name: "Run Rubocop"
     runs-on: ubuntu-latest
-    if: github.repository == 'calagator/calagator'
     steps:
       - uses: actions/checkout@master
-      - name: Rubocop Linter
-        uses: andrewmcodes/rubocop-linter-action@v3.1.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-ruby@v1
+      - name: Install Rubocop
+        run: gem install rubocop rubocop-performance rubocop-rails rubocop-rspec
+      - name: Rubocop
+        run: rubocop --fail-level warning
+      # - name: Rubocop Linter
+      #   uses: andrewmcodes/rubocop-linter-action@v3.1.0
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   test:
     runs-on: ubuntu-latest
 

--- a/db/migrate/20200327040656_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20200327040656_add_missing_indexes_on_taggings.acts_as_taggable_on_engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from acts_as_taggable_on_engine (originally 6)
 if ActiveRecord.gem_version >= Gem::Version.new('5.0')
   class AddMissingIndexesOnTaggings < ActiveRecord::Migration[4.2]; end
@@ -12,12 +14,12 @@ AddMissingIndexesOnTaggings.class_eval do
     add_index :taggings, :tagger_id unless index_exists? :taggings, :tagger_id
     add_index :taggings, :context unless index_exists? :taggings, :context
 
-    unless index_exists? :taggings, [:tagger_id, :tagger_type]
-      add_index :taggings, [:tagger_id, :tagger_type]
+    unless index_exists? :taggings, %i[tagger_id tagger_type]
+      add_index :taggings, %i[tagger_id tagger_type]
     end
 
-    unless index_exists? :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
-      add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+    unless index_exists? :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
+      add_index :taggings, %i[taggable_id taggable_type tagger_id context], name: 'taggings_idy'
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,8 +21,8 @@ require 'selenium-webdriver'
 require 'timecop'
 require 'webmock'
 
-if Object.const_defined? "SimpleCov"
-  SimpleCov.command_name "rspec"
+if Object.const_defined? 'SimpleCov'
+  SimpleCov.command_name 'rspec'
 end
 
 # Load support files


### PR DESCRIPTION
The Checks API requires a token with write permissions, and the `GITHUB_TOKEN` provided to actions for runs from forked PRs can't provide that. I tried a few attempts to exclude this functionality only when running from a fork, but there doesn't seem to be any easy way to detect a forked PR from the actions context. :/