### PR TITLE
Remove use of SortedSet in Source::Parser

### DIFF
--- a/app/models/calagator/source/parser.rb
+++ b/app/models/calagator/source/parser.rb
@@ -30,7 +30,7 @@ module Calagator
     end
     private_class_method :matched_parsers
 
-    cattr_accessor(:parsers) { SortedSet.new }
+    cattr_accessor(:parsers) { Set.new }
 
     def self.inherited(subclass)
       parsers << subclass


### PR DESCRIPTION
SortedSet relies on being able to compare classes with <=>. At some point, either Ruby or Rails did something to support comparing classes based on their names. That no longer seems to be the case.
