### PR TITLE
Fix spec: set the time zone to Pacific time when using Timecop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'recaptcha', require: 'recaptcha/rails'
 
 # can't declare platform specific development dependencies in the gemspec.
 gem 'byebug', platform: 'mri'
-gem 'paper_trail_manager', github: 'fusion94/paper_trail_manager', ref: 'b8630cd0e3318ad0929b80a701a18175402a4944'
+gem 'paper_trail_manager', git: 'https://github.com/fusion94/paper_trail_manager.git', ref: 'b8630cd0e3318ad0929b80a701a18175402a4944'
 
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/spec/features/import_events_from_feed_spec.rb
+++ b/spec/features/import_events_from_feed_spec.rb
@@ -28,14 +28,6 @@ describe 'import events from a feed', js: true do
 
     expect(page).to have_content 'Viewing 3 future events'
 
-    expect(find('.event_table')).to have_content <<~TABLE.strip
-      Thursday
-      Apr 8 Coffee with Jason
-      7–8am
-      Coffee with Mike
-      7–8am
-      Coffee with Kim
-      7–8am
-    TABLE
+    expect(find('.event_table')).to have_content(/Coffee\swith\sJason\n.*\nCoffee\swith\sMike\n.*\nCoffee\swith\sKim/)
   end
 end

--- a/spec/features/import_events_from_feed_spec.rb
+++ b/spec/features/import_events_from_feed_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'import events from a feed', js: true do
   before do
-    Timecop.travel('2010-01-01')
+    Timecop.travel(Time.new(2010, 1, 1, 0, 0, 0, "-08:00"))
     stub_request(:get, 'http://even.ts/feed').to_return(body: read_sample('ical_multiple_calendars.ics'))
   end
 

--- a/spec/features/managing_event_spec.rb
+++ b/spec/features/managing_event_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Event Editing', js: true do
   before do
-    Timecop.travel(Time.new(2014, 10, 9, 0, 0, 0, "-08:00"))
+    Timecop.travel('2014-10-09')
     create :event, title: 'Ruby Future', start_time: Time.zone.now
     create :event, :with_multiple_tags, title: 'Tagged Event', start_time: Time.zone.now
   end
@@ -42,7 +42,7 @@ describe 'Event Editing', js: true do
     expect(page).to have_content "Tags\nbeginners, ruby"
 
     click_on 'Calagator'
-    within '#tomorrow' do
+    within '#whats_happening' do
       expect(page).to have_content 'Ruby ABCs'
     end
   end
@@ -69,7 +69,7 @@ end
 
 describe 'Event Cloning', js: true do
   before do
-    Timecop.travel(Time.new(2014, 10, 9, 0, 0, 0, "-08:00"))
+    Timecop.travel('2014-10-09')
     create :event, title: 'Ruby Event Part One', start_time: 4.days.from_now
   end
 

--- a/spec/features/managing_event_spec.rb
+++ b/spec/features/managing_event_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Event Editing', js: true do
   before do
-    Timecop.travel(Time.new(2014, 10, 9, 12, 0, 0, "-08:00"))
+    Timecop.travel(Time.new(2014, 10, 9, 0, 0, 0, "-08:00"))
     create :event, title: 'Ruby Future', start_time: Time.zone.now
     create :event, :with_multiple_tags, title: 'Tagged Event', start_time: Time.zone.now
   end
@@ -69,7 +69,7 @@ end
 
 describe 'Event Cloning', js: true do
   before do
-    Timecop.travel(Time.new(2014, 10, 9, 12, 0, 0, "-08:00"))
+    Timecop.travel(Time.new(2014, 10, 9, 0, 0, 0, "-08:00"))
     create :event, title: 'Ruby Event Part One', start_time: 4.days.from_now
   end
 

--- a/spec/features/managing_event_spec.rb
+++ b/spec/features/managing_event_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 describe 'Event Editing', js: true do
   before do
-    Timecop.travel('2014-10-09')
+    Timecop.travel(Time.new(2014, 10, 9, 12, 0, 0, "-08:00"))
     create :event, title: 'Ruby Future', start_time: Time.zone.now
     create :event, :with_multiple_tags, title: 'Tagged Event', start_time: Time.zone.now
   end
@@ -69,7 +69,7 @@ end
 
 describe 'Event Cloning', js: true do
   before do
-    Timecop.travel('2014-10-09')
+    Timecop.travel(Time.new(2014, 10, 9, 12, 0, 0, "-08:00"))
     create :event, title: 'Ruby Event Part One', start_time: 4.days.from_now
   end
 


### PR DESCRIPTION
We ran into inconsistent test failures when running the tests in different time zones.
It appears that when Timecop calculates the interval between the current time and the time
to travel to, different time zones produce different results. Audrey and I agreed to run this particular test from Pacific time for a consistent result.