### PR TITLE
Make Calagator models explicitly inherit from Calagator::ApplicationRecord

### DIFF
--- a/app/models/calagator/event.rb
+++ b/app/models/calagator/event.rb
@@ -36,7 +36,7 @@ require 'active_model/serializers/xml'
 # A model representing a calendar event.
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     self.table_name = 'events'
     self.belongs_to_required_by_default = false
 

--- a/app/models/calagator/event/browse.rb
+++ b/app/models/calagator/event/browse.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class Browse < Struct.new(:order, :date, :time)
       def initialize(attributes = {})
         members.each do |key|

--- a/app/models/calagator/event/cloner.rb
+++ b/app/models/calagator/event/cloner.rb
@@ -4,7 +4,7 @@
 # the start_time and end_time adjusted so that their date is set to today and
 # their time-of-day is set to the original record's time-of-day.
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class Cloner < Struct.new(:event)
       def self.clone(event)
         new(event).clone

--- a/app/models/calagator/event/ical_renderer.rb
+++ b/app/models/calagator/event/ical_renderer.rb
@@ -15,7 +15,7 @@
 require 'loofah/helpers'
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class IcalRenderer
       def self.render(events, opts = {})
         output = render_icalendar(events, opts)

--- a/app/models/calagator/event/overview.rb
+++ b/app/models/calagator/event/overview.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class Overview
       def today
         Event.non_duplicates.within_dates(today_date, tomorrow_date)

--- a/app/models/calagator/event/saver.rb
+++ b/app/models/calagator/event/saver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class Saver < Struct.new(:event, :params, :failure)
       def save
         event.attributes = params[:event] || {}

--- a/app/models/calagator/event/search.rb
+++ b/app/models/calagator/event/search.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class Search < Struct.new(:query, :tag, :order, :current)
       def initialize(attributes = {})
         members.each do |key|

--- a/app/models/calagator/event/search_engine.rb
+++ b/app/models/calagator/event/search_engine.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class SearchEngine
       cattr_accessor(:kind) { :sql }
 

--- a/app/models/calagator/event/search_engine/apache_sunspot.rb
+++ b/app/models/calagator/event/search_engine/apache_sunspot.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class SearchEngine
       class ApacheSunspot < Struct.new(:query, :opts)
         # Return an Array of non-duplicate Event instances matching the search +query+..

--- a/app/models/calagator/event/search_engine/sql.rb
+++ b/app/models/calagator/event/search_engine/sql.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Event < ApplicationRecord
+  class Event < Calagator::ApplicationRecord
     class SearchEngine
       class Sql < Struct.new(:query, :opts)
         # Return an Array of non-duplicate Event instances matching the search +query+..

--- a/app/models/calagator/source.rb
+++ b/app/models/calagator/source.rb
@@ -21,7 +21,7 @@ require 'loofah-activerecord'
 require 'loofah/activerecord/xss_foliate'
 
 module Calagator
-  class Source < ApplicationRecord
+  class Source < Calagator::ApplicationRecord
     self.table_name = 'sources'
 
     validate :assert_url

--- a/app/models/calagator/source/importer.rb
+++ b/app/models/calagator/source/importer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Source < ApplicationRecord
+  class Source < Calagator::ApplicationRecord
     class Importer < Struct.new(:source, :events)
       def initialize(params)
         self.source = Source.find_or_create_by(params)

--- a/app/models/calagator/venue.rb
+++ b/app/models/calagator/venue.rb
@@ -37,7 +37,7 @@ require 'validate_url'
 require 'active_model/serializers/xml'
 
 module Calagator
-  class Venue < ApplicationRecord
+  class Venue < Calagator::ApplicationRecord
     self.table_name = 'venues'
 
     include StripWhitespace

--- a/app/models/calagator/venue/geocoder.rb
+++ b/app/models/calagator/venue/geocoder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Venue < ApplicationRecord
+  class Venue < Calagator::ApplicationRecord
     class Geocoder < Struct.new(:venue)
       cattr_accessor(:perform_geocoding) { true }
 

--- a/app/models/calagator/venue/search.rb
+++ b/app/models/calagator/venue/search.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Venue < ApplicationRecord
+  class Venue < Calagator::ApplicationRecord
     class Search < Struct.new(:tag, :query, :wifi, :all, :closed, :include_closed)
       def initialize(attributes = {})
         members.each do |key|

--- a/app/models/calagator/venue/search_engine.rb
+++ b/app/models/calagator/venue/search_engine.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Venue < ApplicationRecord
+  class Venue < Calagator::ApplicationRecord
     class SearchEngine
       cattr_accessor(:kind) { :sql }
 

--- a/app/models/calagator/venue/search_engine/apache_sunspot.rb
+++ b/app/models/calagator/venue/search_engine/apache_sunspot.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Venue < ApplicationRecord
+  class Venue < Calagator::ApplicationRecord
     class SearchEngine
       class ApacheSunspot < Struct.new(:query, :opts)
         # Return an Array of non-duplicate Venue instances matching the search +query+..

--- a/app/models/calagator/venue/search_engine/sql.rb
+++ b/app/models/calagator/venue/search_engine/sql.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Calagator
-  class Venue < ApplicationRecord
+  class Venue < Calagator::ApplicationRecord
     class SearchEngine
       class Sql < Struct.new(:query, :opts)
         def self.search(*args)

--- a/lib/calagator/denylist_validator.rb
+++ b/lib/calagator/denylist_validator.rb
@@ -15,7 +15,7 @@
 #
 # And then you'd include the denylisting feature into your Message class like:
 #
-#   class Message < ApplicationRecord
+#   class Message < Calagator::ApplicationRecord
 #     validates :title, :content, denylist: true
 #   end
 #

--- a/lib/calagator/duplicate_checking.rb
+++ b/lib/calagator/duplicate_checking.rb
@@ -7,7 +7,7 @@
 # Example:
 #
 #   # Define your class
-#   class Thing < ApplicationRecord
+#   class Thing < Calagator::ApplicationRecord
 #     # Load the mixin into your class
 #     include DuplicateChecking
 #


### PR DESCRIPTION
Without this, preloading in production can resolve to the host app's ApplicationRecord and cause errors like `TypeError: superclass mismatch for class Event`
