### PR TITLE
chore: Require minimum of Ruby 2.6

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,9 +44,8 @@ jobs:
           - postgresql
           - sqlite3
         ruby:
-          - 2.5.9
-          - 2.6.9
-          - 2.7.5
+          - 2.6.10
+          - 2.7.6
         rails:
           - rails_5_2
         # exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ require:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
   Exclude:
     - 'spec/test_app/**/*'
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ List of Calagator releases and changes, with the latest at the top:
 
 ### v2.0.0 (unreleased)
 
+  * [!] Upgrade to minimum Ruby version 2.6.
   * [!] Upgrade to Rails 5 with minimum Ruby version 2.5.
   * [!] Remove inappropriate terminology such as master, slave, and blacklist. Existing `blacklist.txt` files will need to be renamed to `denylist.txt` when upgrading a Rails app that uses earlier versions of this gem.
   * [!] Meetup and Facebook integration is no longer supported due to changes to these services' APIs. Their API keys should be removed from your configuration.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -61,6 +61,7 @@ These people have contributed to Calagator's design and implementation:
   * Patrick McSweeny
   * Reid Beels
   * Ryan McCarthy
+  * Ryan Williams
   * Sam Keen
   * Sam Livingston-Gray
   * Scott Becker

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,7 +4,7 @@ Calagator is distributed as a [Rails engine](http://guides.rubyonrails.org/engin
 
 ## Requirements
 
-Calagator requires Ruby >= 2.5.0, and a host application built on Rails 5 or newer.
+Calagator requires Ruby >= 2.6.0, and a host application built on Rails 5 or newer.
 
 ## Running a site based on Calagator
 

--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.description = 'Calagator is an open source community calendaring platform'
   s.license     = 'MIT'
 
-  s.required_ruby_version = ['>= 2.5.0']
+  s.required_ruby_version = ['>= 2.6.0']
 
   s.files = Dir['{app,config,lib,vendor}/**/*'] + Dir['db/**/*.rb'] + ['MIT-LICENSE.txt', 'Rakefile', 'README.md', 'rails_template.rb']
   s.test_files = Dir['spec/**/*']

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -3,7 +3,7 @@
 APPDIR="/vagrant"
 VAGRANT_USER="vagrant"
 PGSQL_VERSION=9.3
-RUBY_VERSION=2.1
+RUBY_VERSION=2.6
 
 # Fix locale so that Postgres creates databases in UTF-8
 if [ "${LANG}" != "en_US.UTF-8" ] ; then


### PR DESCRIPTION
With Ruby 2.5 and 2.6 now EOL, this update begins working towards Ruby 2.7+ by dropping support for Ruby 2.5 and ensuring development can be done on Ruby 2.6.

```
Ruby 2.6
status: eol
release date: 2018-12-25
EOL date: 2022-04-12

Ruby 2.5
status: eol
release date: 2017-12-25
EOL date: 2021-04-05
```

https://www.ruby-lang.org/en/downloads/branches/

