### PR TITLE
Updates ‘pg’ gem to 0.19.0 in Gemfiles and Appraisals to match version required by the gem.

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,6 +5,6 @@ appraise 'rails-5-2' do
   gem 'turbolinks'
 
   gem 'mysql2', '~> 0.5.3'
-  gem 'pg', '~> 0.18.1'
+  gem 'pg', '~> 0.19'
   gem 'rails-controller-testing', group: 'test'
 end

--- a/calagator.gemspec
+++ b/calagator.gemspec
@@ -51,6 +51,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'utf8-cleaner', '>= 0.0.6', '< 1.1.0'
   s.add_dependency 'validate_url'
   s.add_dependency 'will_paginate', '~> 3.0'
+  s.add_dependency 'pg', '~> 0.19.0'
 
   s.add_development_dependency 'appraisal', '~> 2.4'
   s.add_development_dependency 'capybara', '~> 3.31'

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -10,6 +10,6 @@ gem "paper_trail_manager", git: "https://github.com/fusion94/paper_trail_manager
 gem "launchy"
 gem "rails-controller-testing", group: "test"
 gem "mysql2", "~> 0.5.3"
-gem "pg", "~> 0.18.1"
+gem "pg", "~> 0.19"
 
 gemspec path: "../"


### PR DESCRIPTION
 Fixes: calagator was resolved to 2.0.0.pre.1, which depends on pg (~> 0.19.0)

Currently running ‘bundle exec appraisal install’ generates: 
```
Bundler could not find compatible versions for gem "pg":
  In rails_5_2.gemfile:
    pg (~> 0.18.1)

    calagator was resolved to 2.0.0.pre.1, which depends on
      pg (~> 0.19.0)
```