### PR TITLE
Add ML classifier to reject spam events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', '~> 5.2'
 gem 'turbolinks'
 
 gem 'recaptcha', require: 'recaptcha/rails'
-
+gem 'rest-client'
 # can't declare platform specific development dependencies in the gemspec.
 gem 'byebug', platform: 'mri'
 gem 'paper_trail_manager', git: 'https://github.com/fusion94/paper_trail_manager.git', ref: 'b8630cd0e3318ad0929b80a701a18175402a4944'

--- a/app/controllers/calagator/application_controller.rb
+++ b/app/controllers/calagator/application_controller.rb
@@ -16,6 +16,7 @@ module Calagator
 
     helper :all # include all helpers, all the time
     helper_method :recaptcha_enabled?
+    helper_method :spam_detector_enabled?
 
     # See ActionController::RequestForgeryProtection for details
     # Uncomment the :secret if you're not using the cookie session store
@@ -27,6 +28,10 @@ module Calagator
     end
 
     protected
+
+    def spam_detector_enabled?
+      !ENV["GPTURK_SPAM_MODEL_ID"].to_s.empty?
+    end
 
     def json_request?
       request.format.json?

--- a/app/models/calagator/event/saver.rb
+++ b/app/models/calagator/event/saver.rb
@@ -34,7 +34,17 @@ module Calagator
       end
 
       def spam?
-        evil_robot? || too_many_links?
+        evil_robot? || too_many_links? || ml_flags_as_spam?
+      end
+
+      def get_spam_label
+        GpturkService.get_spam_label("#{params.dig(:event, :title)} #{params.dig(:event, :description)} #{params[:start_date]} at #{params[:start_time]}")
+      end
+
+      def ml_flags_as_spam?
+        if get_spam_label == 1
+          self.failure = "<h3>Spammer</h3> We didn't save this event because we think this looks like a spammy event. If this isn't spam and is a legitimate event, please file a bug report and let us know."
+        end
       end
 
       def evil_robot?

--- a/app/services/gpturk_service.rb
+++ b/app/services/gpturk_service.rb
@@ -1,0 +1,12 @@
+module GpturkService
+  require 'rest-client'
+  require 'json'
+
+  def self.get_spam_label(text)
+    url = "https://gpturk.cognitivesurpl.us/api/tasks/#{ENV["GPTURK_SPAM_MODEL_ID"]}/inferences"
+    headers = { 'Content-Type' => 'application/json' }
+    payload = { api_key: ENV["GPTURK_API_KEY"], text: text }.to_json
+    response = RestClient.post(url, payload, headers)
+    JSON.parse(response.body)["label"]["parsed_label"].to_i
+  end
+end

--- a/spec/controllers/calagator/events_controller_spec.rb
+++ b/spec/controllers/calagator/events_controller_spec.rb
@@ -5,6 +5,17 @@ require './spec/controllers/squash_many_duplicates_examples'
 
 module Calagator
   describe EventsController, type: :controller do
+    before do
+      stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+        with(
+          headers: {
+        	  'Accept'=>'*/*',
+        	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        	  'Content-Type'=>'application/json',
+        	  'Host'=>'gpturk.cognitivesurpl.us',
+          }).
+        to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"0\"}}", headers: {})
+    end
     routes { Calagator::Engine.routes }
 
     describe '#index' do
@@ -401,6 +412,21 @@ module Calagator
           expect(flash[:failure]).to match /evil robot/i
         end
 
+        it 'stops spammers' do
+          stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+            with(
+              headers: {
+            	  'Accept'=>'*/*',
+            	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            	  'Content-Type'=>'application/json',
+            	  'Host'=>'gpturk.cognitivesurpl.us',
+              }).
+            to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"1\"}}", headers: {})
+          post :create, params: @params
+          expect(response).to render_template :new
+          expect(flash[:failure]).to match /spammy event/i
+        end
+
         it 'does not allow too many links in the description' do
           @params[:event][:description] = <<-DESC
           http://example.com
@@ -524,6 +550,22 @@ module Calagator
           expect(response).to render_template :edit
           expect(flash[:failure]).to match /evil robot/i
         end
+
+        it 'stops spammers' do
+          stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+            with(
+              headers: {
+            	  'Accept'=>'*/*',
+            	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            	  'Content-Type'=>'application/json',
+            	  'Host'=>'gpturk.cognitivesurpl.us',
+              }).
+            to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"1\"}}", headers: {})
+          put 'update', params: @params
+          expect(response).to render_template :edit
+          expect(flash[:failure]).to match /spammy event/i
+        end
+        
 
         it 'does not allow too many links in the description' do
           @params[:event][:description] = <<-DESC

--- a/spec/features/add_event_spec.rb
+++ b/spec/features/add_event_spec.rb
@@ -7,6 +7,15 @@ describe 'Event Creation', js: true do
     create :venue, title: 'Empire State Building'
     create :venue, title: 'New Relic'
     create :venue, title: 'Urban Airship'
+    stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+      with(
+        headers: {
+      	  'Accept'=>'*/*',
+      	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      	  'Content-Type'=>'application/json',
+      	  'Host'=>'gpturk.cognitivesurpl.us',
+        }).
+      to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"0\"}}", headers: {})
   end
 
   it 'User adds an event at an existing venue' do

--- a/spec/features/managing_event_spec.rb
+++ b/spec/features/managing_event_spec.rb
@@ -7,6 +7,15 @@ describe 'Event Editing', js: true do
     Timecop.travel('2014-10-09')
     create :event, title: 'Ruby Future', start_time: Time.zone.now
     create :event, :with_multiple_tags, title: 'Tagged Event', start_time: Time.zone.now
+    stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+      with(
+        headers: {
+      	  'Accept'=>'*/*',
+      	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      	  'Content-Type'=>'application/json',
+      	  'Host'=>'gpturk.cognitivesurpl.us',
+        }).
+      to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"0\"}}", headers: {})
   end
 
   after do
@@ -71,6 +80,15 @@ describe 'Event Cloning', js: true do
   before do
     Timecop.travel('2014-10-09')
     create :event, title: 'Ruby Event Part One', start_time: 4.days.from_now
+    stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+      with(
+        headers: {
+      	  'Accept'=>'*/*',
+      	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+      	  'Content-Type'=>'application/json',
+      	  'Host'=>'gpturk.cognitivesurpl.us',
+        }).
+      to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"0\"}}", headers: {})
   end
 
   after do

--- a/spec/models/calagator/event/saver_spec.rb
+++ b/spec/models/calagator/event/saver_spec.rb
@@ -4,6 +4,17 @@ require 'spec_helper'
 
 module Calagator
   describe Event::Saver do
+    before do
+      stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+        with(
+          headers: {
+        	  'Accept'=>'*/*',
+        	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+        	  'Content-Type'=>'application/json',
+        	  'Host'=>'gpturk.cognitivesurpl.us',
+          }).
+        to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"0\"}}", headers: {})
+    end
     let(:event) { build :event }
     let(:imported_event) { create :event, :with_source }
     let(:params) { { venue_name: 'Name of Venue' } }
@@ -30,6 +41,21 @@ module Calagator
         saver = described_class.new(event, params)
         saver.save
         expect(saver.failure).to include "you're an evil robot"
+      end
+
+      it 'fails to save an event made by a spammer' do
+        stub_request(:post, %r{https?://gpturk\.cognitivesurpl\.us/.*}).
+          with(
+            headers: {
+          	  'Accept'=>'*/*',
+          	  'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          	  'Content-Type'=>'application/json',
+          	  'Host'=>'gpturk.cognitivesurpl.us',
+            }).
+          to_return(status: 200, body: "{\"label\":{\"parsed_label\":\"1\"}}", headers: {})
+        saver = described_class.new(event, params)
+        saver.save
+        expect(saver.failure).to include "spammy event"
       end
 
       it 'does not save an event being previewed' do


### PR DESCRIPTION
As [referenced in my other message](https://github.com/calagator/calagator/discussions/701#discussioncomment-6451008), here's an implementation where we can use a classifier to reject spam events. The one thing I don't love is that this requires HTTP requests during an HTTP request, but no way to get around that without putting some other job logic into calagator afaict